### PR TITLE
Refactor resource patching

### DIFF
--- a/apis/lagoon/v1beta1/lagoonmessaging_types.go
+++ b/apis/lagoon/v1beta1/lagoonmessaging_types.go
@@ -55,5 +55,6 @@ type LagoonMessage struct {
 type LagoonStatusMessages struct {
 	StatusMessage      *LagoonLog     `json:"statusMessage,omitempty"`
 	BuildLogMessage    *LagoonLog     `json:"buildLogMessage,omitempty"`
+	TaskLogMessage     *LagoonLog     `json:"taskLogMessage,omitempty"`
 	EnvironmentMessage *LagoonMessage `json:"environmentMessage,omitempty"`
 }

--- a/apis/lagoon/v1beta1/zz_generated.deepcopy.go
+++ b/apis/lagoon/v1beta1/zz_generated.deepcopy.go
@@ -336,6 +336,11 @@ func (in *LagoonStatusMessages) DeepCopyInto(out *LagoonStatusMessages) {
 		*out = new(LagoonLog)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.TaskLogMessage != nil {
+		in, out := &in.TaskLogMessage, &out.TaskLogMessage
+		*out = new(LagoonLog)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.EnvironmentMessage != nil {
 		in, out := &in.EnvironmentMessage, &out.EnvironmentMessage
 		*out = new(LagoonMessage)

--- a/config/crd/bases/crd.lagoon.sh_lagoonbuilds.yaml
+++ b/config/crd/bases/crd.lagoon.sh_lagoonbuilds.yaml
@@ -481,6 +481,103 @@ spec:
                   uuid:
                     type: string
                 type: object
+              taskLogMessage:
+                description: LagoonLog is used to sendToLagoonLogs messaging queue
+                  this is general logging information
+                properties:
+                  event:
+                    type: string
+                  message:
+                    type: string
+                  meta:
+                    description: LagoonLogMeta is the metadata that is used by logging
+                      in Lagoon.
+                    properties:
+                      advancedData:
+                        type: string
+                      branchName:
+                        type: string
+                      buildName:
+                        type: string
+                      buildPhase:
+                        type: string
+                      buildStatus:
+                        type: string
+                      buildStep:
+                        type: string
+                      clusterName:
+                        type: string
+                      endTime:
+                        type: string
+                      environment:
+                        type: string
+                      environmentId:
+                        type: integer
+                      jobName:
+                        type: string
+                      jobStatus:
+                        type: string
+                      jobStep:
+                        type: string
+                      key:
+                        type: string
+                      logLink:
+                        type: string
+                      monitoringUrls:
+                        items:
+                          type: string
+                        type: array
+                      project:
+                        type: string
+                      projectId:
+                        type: integer
+                      projectName:
+                        type: string
+                      remoteId:
+                        type: string
+                      route:
+                        type: string
+                      routes:
+                        items:
+                          type: string
+                        type: array
+                      services:
+                        items:
+                          type: string
+                        type: array
+                      startTime:
+                        type: string
+                      task:
+                        description: LagoonTaskInfo defines what a task can use to
+                          communicate with Lagoon via SSH/API.
+                        properties:
+                          apiHost:
+                            type: string
+                          command:
+                            type: string
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          service:
+                            type: string
+                          sshHost:
+                            type: string
+                          sshPort:
+                            type: string
+                          taskName:
+                            type: string
+                        required:
+                        - id
+                        type: object
+                    type: object
+                  project:
+                    type: string
+                  severity:
+                    type: string
+                  uuid:
+                    type: string
+                type: object
             type: object
         type: object
     served: true

--- a/config/crd/bases/crd.lagoon.sh_lagoontasks.yaml
+++ b/config/crd/bases/crd.lagoon.sh_lagoontasks.yaml
@@ -450,6 +450,103 @@ spec:
                   uuid:
                     type: string
                 type: object
+              taskLogMessage:
+                description: LagoonLog is used to sendToLagoonLogs messaging queue
+                  this is general logging information
+                properties:
+                  event:
+                    type: string
+                  message:
+                    type: string
+                  meta:
+                    description: LagoonLogMeta is the metadata that is used by logging
+                      in Lagoon.
+                    properties:
+                      advancedData:
+                        type: string
+                      branchName:
+                        type: string
+                      buildName:
+                        type: string
+                      buildPhase:
+                        type: string
+                      buildStatus:
+                        type: string
+                      buildStep:
+                        type: string
+                      clusterName:
+                        type: string
+                      endTime:
+                        type: string
+                      environment:
+                        type: string
+                      environmentId:
+                        type: integer
+                      jobName:
+                        type: string
+                      jobStatus:
+                        type: string
+                      jobStep:
+                        type: string
+                      key:
+                        type: string
+                      logLink:
+                        type: string
+                      monitoringUrls:
+                        items:
+                          type: string
+                        type: array
+                      project:
+                        type: string
+                      projectId:
+                        type: integer
+                      projectName:
+                        type: string
+                      remoteId:
+                        type: string
+                      route:
+                        type: string
+                      routes:
+                        items:
+                          type: string
+                        type: array
+                      services:
+                        items:
+                          type: string
+                        type: array
+                      startTime:
+                        type: string
+                      task:
+                        description: LagoonTaskInfo defines what a task can use to
+                          communicate with Lagoon via SSH/API.
+                        properties:
+                          apiHost:
+                            type: string
+                          command:
+                            type: string
+                          id:
+                            type: string
+                          name:
+                            type: string
+                          service:
+                            type: string
+                          sshHost:
+                            type: string
+                          sshPort:
+                            type: string
+                          taskName:
+                            type: string
+                        required:
+                        - id
+                        type: object
+                    type: object
+                  project:
+                    type: string
+                  severity:
+                    type: string
+                  uuid:
+                    type: string
+                type: object
             type: object
         type: object
     served: true

--- a/controllers/v1beta1/build_controller.go
+++ b/controllers/v1beta1/build_controller.go
@@ -121,11 +121,12 @@ func (r *LagoonBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// then clean up the undeployable build
 		if value, ok := lagoonBuild.ObjectMeta.Labels["lagoon.sh/buildStatus"]; ok {
 			if value == string(lagoonv1beta1.BuildStatusCancelled) {
-				opLog.Info(fmt.Sprintf("Cleaning up build %s as cancelled", lagoonBuild.ObjectMeta.Name))
 				if value, ok := lagoonBuild.ObjectMeta.Labels["lagoon.sh/cancelledByNewBuild"]; ok {
 					if value == "true" {
+						opLog.Info(fmt.Sprintf("Cleaning up build %s as cancelled by new build", lagoonBuild.ObjectMeta.Name))
 						r.cleanUpUndeployableBuild(ctx, lagoonBuild, "This build was cancelled as a newer build was triggered.", opLog, true)
 					} else {
+						opLog.Info(fmt.Sprintf("Cleaning up build %s as cancelled", lagoonBuild.ObjectMeta.Name))
 						r.cleanUpUndeployableBuild(ctx, lagoonBuild, "", opLog, false)
 					}
 				}
@@ -150,8 +151,10 @@ func (r *LagoonBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				// if the running build is the one from this request then process it
 				if lagoonBuild.ObjectMeta.Name == runningBuild.ObjectMeta.Name {
 					// actually process the build here
-					if err := r.processBuild(ctx, opLog, lagoonBuild); err != nil {
-						return ctrl.Result{}, err
+					if _, ok := lagoonBuild.ObjectMeta.Labels["lagoon.sh/buildStarted"]; !ok {
+						if err := r.processBuild(ctx, opLog, lagoonBuild); err != nil {
+							return ctrl.Result{}, err
+						}
 					}
 				} // end check if running build is current LagoonBuild
 			} // end loop for running builds

--- a/controllers/v1beta1/build_controller.go
+++ b/controllers/v1beta1/build_controller.go
@@ -210,20 +210,26 @@ func (r *LagoonBuildReconciler) createNamespaceBuild(ctx context.Context,
 	lagoonBuild lagoonv1beta1.LagoonBuild) (ctrl.Result, error) {
 
 	namespace := &corev1.Namespace{}
-	opLog.Info(fmt.Sprintf("Checking Namespace exists for: %s", lagoonBuild.ObjectMeta.Name))
+	if r.EnableDebug {
+		opLog.Info(fmt.Sprintf("Checking Namespace exists for: %s", lagoonBuild.ObjectMeta.Name))
+	}
 	err := r.getOrCreateNamespace(ctx, namespace, lagoonBuild, opLog)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	// create the `lagoon-deployer` ServiceAccount
-	opLog.Info(fmt.Sprintf("Checking `lagoon-deployer` ServiceAccount exists: %s", lagoonBuild.ObjectMeta.Name))
+	if r.EnableDebug {
+		opLog.Info(fmt.Sprintf("Checking `lagoon-deployer` ServiceAccount exists: %s", lagoonBuild.ObjectMeta.Name))
+	}
 	serviceAccount := &corev1.ServiceAccount{}
 	err = r.getOrCreateServiceAccount(ctx, serviceAccount, namespace.ObjectMeta.Name)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	// ServiceAccount RoleBinding creation
-	opLog.Info(fmt.Sprintf("Checking `lagoon-deployer-admin` RoleBinding exists: %s", lagoonBuild.ObjectMeta.Name))
+	if r.EnableDebug {
+		opLog.Info(fmt.Sprintf("Checking `lagoon-deployer-admin` RoleBinding exists: %s", lagoonBuild.ObjectMeta.Name))
+	}
 	saRoleBinding := &rbacv1.RoleBinding{}
 	err = r.getOrCreateSARoleBinding(ctx, saRoleBinding, namespace.ObjectMeta.Name)
 	if err != nil {

--- a/controllers/v1beta1/build_helpers.go
+++ b/controllers/v1beta1/build_helpers.go
@@ -944,13 +944,13 @@ func (r *LagoonBuildReconciler) cancelExtraBuilds(ctx context.Context, opLog log
 	if err := r.List(ctx, pendingBuilds, listOption); err != nil {
 		return fmt.Errorf("Unable to list builds in the namespace, there may be none or something went wrong: %v", err)
 	}
-	opLog.Info(fmt.Sprintf("There are %v Pending builds", len(pendingBuilds.Items)))
-	// if we have any pending builds, then grab the latest one and make it running
-	// if there are any other pending builds, cancel them so only the latest one runs
-	sort.Slice(pendingBuilds.Items, func(i, j int) bool {
-		return pendingBuilds.Items[i].ObjectMeta.CreationTimestamp.After(pendingBuilds.Items[j].ObjectMeta.CreationTimestamp.Time)
-	})
 	if len(pendingBuilds.Items) > 0 {
+		opLog.Info(fmt.Sprintf("There are %v Pending builds", len(pendingBuilds.Items)))
+		// if we have any pending builds, then grab the latest one and make it running
+		// if there are any other pending builds, cancel them so only the latest one runs
+		sort.Slice(pendingBuilds.Items, func(i, j int) bool {
+			return pendingBuilds.Items[i].ObjectMeta.CreationTimestamp.After(pendingBuilds.Items[j].ObjectMeta.CreationTimestamp.Time)
+		})
 		for idx, pBuild := range pendingBuilds.Items {
 			pendingBuild := pBuild.DeepCopy()
 			if idx == 0 {

--- a/controllers/v1beta1/build_qoshandler.go
+++ b/controllers/v1beta1/build_qoshandler.go
@@ -65,28 +65,28 @@ func (r *LagoonBuildReconciler) whichBuildNext(ctx context.Context, opLog logr.L
 		if err := r.List(ctx, pendingBuilds, listOption); err != nil {
 			return fmt.Errorf("Unable to list builds in the cluster, there may be none or something went wrong: %v", err)
 		}
-		opLog.Info(fmt.Sprintf("There are %v Pending builds", len(pendingBuilds.Items)))
-		// if we have any pending builds, then grab the latest one and make it running
-		// if there are any other pending builds, cancel them so only the latest one runs
-		sort.Slice(pendingBuilds.Items, func(i, j int) bool {
-			// sort by priority, then creation timestamp
-			iPriority := r.BuildQoS.DefaultValue
-			jPriority := r.BuildQoS.DefaultValue
-			if ok := pendingBuilds.Items[i].Spec.Build.Priority; ok != nil {
-				iPriority = *pendingBuilds.Items[i].Spec.Build.Priority
-			}
-			if ok := pendingBuilds.Items[j].Spec.Build.Priority; ok != nil {
-				jPriority = *pendingBuilds.Items[j].Spec.Build.Priority
-			}
-			if iPriority < jPriority {
-				return false
-			}
-			if iPriority > jPriority {
-				return true
-			}
-			return pendingBuilds.Items[i].ObjectMeta.CreationTimestamp.Before(&pendingBuilds.Items[j].ObjectMeta.CreationTimestamp)
-		})
 		if len(pendingBuilds.Items) > 0 {
+			opLog.Info(fmt.Sprintf("There are %v Pending builds", len(pendingBuilds.Items)))
+			// if we have any pending builds, then grab the latest one and make it running
+			// if there are any other pending builds, cancel them so only the latest one runs
+			sort.Slice(pendingBuilds.Items, func(i, j int) bool {
+				// sort by priority, then creation timestamp
+				iPriority := r.BuildQoS.DefaultValue
+				jPriority := r.BuildQoS.DefaultValue
+				if ok := pendingBuilds.Items[i].Spec.Build.Priority; ok != nil {
+					iPriority = *pendingBuilds.Items[i].Spec.Build.Priority
+				}
+				if ok := pendingBuilds.Items[j].Spec.Build.Priority; ok != nil {
+					jPriority = *pendingBuilds.Items[j].Spec.Build.Priority
+				}
+				if iPriority < jPriority {
+					return false
+				}
+				if iPriority > jPriority {
+					return true
+				}
+				return pendingBuilds.Items[i].ObjectMeta.CreationTimestamp.Before(&pendingBuilds.Items[j].ObjectMeta.CreationTimestamp)
+			})
 			for idx, pBuild := range pendingBuilds.Items {
 				if idx <= buildsToStart {
 					// if we do have a `lagoon.sh/buildStatus` set, then process as normal

--- a/controllers/v1beta1/build_standardhandler.go
+++ b/controllers/v1beta1/build_standardhandler.go
@@ -42,8 +42,10 @@ func (r *LagoonBuildReconciler) standardBuildProcessor(ctx context.Context,
 		// if the running build is the one from this request then process it
 		if lagoonBuild.ObjectMeta.Name == runningBuild.ObjectMeta.Name {
 			// actually process the build here
-			if err := r.processBuild(ctx, opLog, lagoonBuild); err != nil {
-				return ctrl.Result{}, err
+			if _, ok := lagoonBuild.ObjectMeta.Labels["lagoon.sh/buildStarted"]; !ok {
+				if err := r.processBuild(ctx, opLog, lagoonBuild); err != nil {
+					return ctrl.Result{}, err
+				}
 			}
 		} // end check if running build is current LagoonBuild
 	} // end loop for running builds

--- a/controllers/v1beta1/harborintegration.go
+++ b/controllers/v1beta1/harborintegration.go
@@ -140,7 +140,7 @@ func (h *Harbor) RotateRobotCredentials(ctx context.Context, cl client.Client) {
 		// could break the build
 		if len(lagoonBuilds.Items) > 0 {
 			if helpers.ContainsString(
-				helpers.RunningPendingStatus,
+				helpers.BuildRunningPendingStatus,
 				lagoonBuilds.Items[0].Labels["lagoon.sh/buildStatus"],
 			) {
 				runningBuilds = true

--- a/controllers/v1beta1/podmonitor_buildhandlers.go
+++ b/controllers/v1beta1/podmonitor_buildhandlers.go
@@ -40,15 +40,12 @@ func (r *LagoonMonitorReconciler) handleBuildMonitor(ctx context.Context,
 	if cancelBuild, ok := jobPod.ObjectMeta.Labels["lagoon.sh/cancelBuild"]; ok {
 		cancel, _ := strconv.ParseBool(cancelBuild)
 		if cancel {
-			return r.updateDeploymentWithLogs(ctx, req, lagoonBuild, jobPod, cancel)
+			return r.updateDeploymentWithLogs(ctx, req, lagoonBuild, jobPod, nil, cancel)
 		}
 	}
 	// check if the build pod is in pending, a container in the pod could be failed in this state
 	if jobPod.Status.Phase == corev1.PodPending {
-		opLog.Info(fmt.Sprintf("Build %s is %v", jobPod.ObjectMeta.Labels["lagoon.sh/buildName"], jobPod.Status.Phase))
-		// send any messages to lagoon message queues
-		r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &jobPod, nil)
-		r.updateDeploymentAndEnvironmentTask(ctx, opLog, &lagoonBuild, &jobPod, nil)
+		// opLog.Info(fmt.Sprintf("Build %s is %v", jobPod.ObjectMeta.Labels["lagoon.sh/buildName"], jobPod.Status.Phase))
 		// check each container in the pod
 		for _, container := range jobPod.Status.ContainerStatuses {
 			// if the container is a lagoon-build container
@@ -78,10 +75,6 @@ func (r *LagoonMonitorReconciler) handleBuildMonitor(ctx context.Context,
 						},
 					}
 					jobPod.Status.ContainerStatuses[0] = state
-					r.updateBuildStatusCondition(ctx, &lagoonBuild, lagoonv1beta1.LagoonBuildConditions{
-						Type:   lagoonv1beta1.BuildStatusFailed,
-						Status: corev1.ConditionTrue,
-					}, []byte(container.State.Waiting.Message))
 
 					// get the configmap for lagoon-env so we can use it for updating the deployment in lagoon
 					var lagoonEnv corev1.ConfigMap
@@ -92,19 +85,15 @@ func (r *LagoonMonitorReconciler) handleBuildMonitor(ctx context.Context,
 						opLog.Info(fmt.Sprintf("There is no configmap %s in namespace %s ", "lagoon-env", jobPod.ObjectMeta.Namespace))
 					}
 					// send any messages to lagoon message queues
-					r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &jobPod, &lagoonEnv)
-					r.updateDeploymentAndEnvironmentTask(ctx, opLog, &lagoonBuild, &jobPod, &lagoonEnv)
 					logMsg := fmt.Sprintf("%v: %v", container.State.Waiting.Reason, container.State.Waiting.Message)
-					r.buildLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &jobPod, []byte(logMsg))
-					return nil
+					return r.updateDeploymentWithLogs(ctx, req, lagoonBuild, jobPod, []byte(logMsg), false)
 				}
 			}
 		}
-		return nil
+		return r.updateDeploymentWithLogs(ctx, req, lagoonBuild, jobPod, nil, false)
 	} else if jobPod.Status.Phase == corev1.PodRunning {
 		// if the pod is running and detects a change to the pod (eg, detecting an updated lagoon.sh/buildStep label)
 		// then ship or store the logs
-		opLog.Info(fmt.Sprintf("Build %s is %v", jobPod.ObjectMeta.Labels["lagoon.sh/buildName"], jobPod.Status.Phase))
 		// get the build associated to this pod, the information in the resource is used for shipping the logs
 		var lagoonBuild lagoonv1beta1.LagoonBuild
 		err := r.Get(ctx,
@@ -115,8 +104,6 @@ func (r *LagoonMonitorReconciler) handleBuildMonitor(ctx context.Context,
 		if err != nil {
 			return err
 		}
-		// actually run the log collection and shipping function
-		r.updateRunningDeploymentBuildLogs(ctx, req, lagoonBuild, jobPod)
 	}
 	// if the buildpod status is failed or succeeded
 	// mark the build accordingly and ship the information back to lagoon
@@ -131,14 +118,10 @@ func (r *LagoonMonitorReconciler) handleBuildMonitor(ctx context.Context,
 		if err != nil {
 			return err
 		}
-		return r.updateDeploymentWithLogs(ctx, req, lagoonBuild, jobPod, false)
 	}
-	// if it isn't pending, failed, or complete, it will be running, we should tell lagoon
-	opLog.Info(fmt.Sprintf("Build %s is %v", jobPod.ObjectMeta.Labels["lagoon.sh/buildName"], jobPod.Status.Phase))
+	// opLog.Info(fmt.Sprintf("Build %s is %v", jobPod.ObjectMeta.Labels["lagoon.sh/buildName"], jobPod.Status.Phase))
 	// send any messages to lagoon message queues
-	r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &jobPod, nil)
-	r.updateDeploymentAndEnvironmentTask(ctx, opLog, &lagoonBuild, &jobPod, nil)
-	return nil
+	return r.updateDeploymentWithLogs(ctx, req, lagoonBuild, jobPod, nil, false)
 }
 
 // buildLogsToLagoonLogs sends the build logs to the lagoon-logs message queue
@@ -148,7 +131,7 @@ func (r *LagoonMonitorReconciler) buildLogsToLagoonLogs(ctx context.Context,
 	lagoonBuild *lagoonv1beta1.LagoonBuild,
 	jobPod *corev1.Pod,
 	logs []byte,
-) {
+) (bool, lagoonv1beta1.LagoonLog) {
 	if r.EnableMQ {
 		condition := "pending"
 		switch jobPod.Status.Phase {
@@ -199,13 +182,13 @@ Logs on pod %s
 			// if we can't publish the message, set it as a pending message
 			// overwrite whatever is there as these are just current state messages so it doesn't
 			// really matter if we don't smootly transition in what we send back to lagoon
-			r.updateBuildLogMessage(ctx, lagoonBuild, msg)
-			return
+			// r.updateBuildLogMessage(ctx, lagoonBuild, msg)
+			return true, msg
 		}
 		// if we are able to publish the message, then we need to remove any pending messages from the resource
 		// and make sure we don't try and publish again
-		r.removeBuildPendingMessageStatus(ctx, lagoonBuild)
 	}
+	return false, lagoonv1beta1.LagoonLog{}
 }
 
 // updateDeploymentAndEnvironmentTask sends the status of the build and deployment to the controllerhandler message queue in lagoon,
@@ -215,7 +198,7 @@ func (r *LagoonMonitorReconciler) updateDeploymentAndEnvironmentTask(ctx context
 	lagoonBuild *lagoonv1beta1.LagoonBuild,
 	jobPod *corev1.Pod,
 	lagoonEnv *corev1.ConfigMap,
-) {
+) (bool, lagoonv1beta1.LagoonMessage) {
 	namespace := helpers.GenerateNamespaceName(
 		lagoonBuild.Spec.Project.NamespacePattern, // the namespace pattern or `openshiftProjectPattern` from Lagoon is never received by the controller
 		lagoonBuild.Spec.Project.Environment,
@@ -334,13 +317,13 @@ func (r *LagoonMonitorReconciler) updateDeploymentAndEnvironmentTask(ctx context
 			// if we can't publish the message, set it as a pending message
 			// overwrite whatever is there as these are just current state messages so it doesn't
 			// really matter if we don't smootly transition in what we send back to lagoon
-			r.updateEnvironmentMessage(ctx, lagoonBuild, msg)
-			return
+			// r.updateEnvironmentMessage(ctx, lagoonBuild, msg)
+			return true, msg
 		}
 		// if we are able to publish the message, then we need to remove any pending messages from the resource
 		// and make sure we don't try and publish again
-		r.removeBuildPendingMessageStatus(ctx, lagoonBuild)
 	}
+	return false, lagoonv1beta1.LagoonMessage{}
 }
 
 // buildStatusLogsToLagoonLogs sends the logs to lagoon-logs message queue, used for general messaging
@@ -348,7 +331,8 @@ func (r *LagoonMonitorReconciler) buildStatusLogsToLagoonLogs(ctx context.Contex
 	opLog logr.Logger,
 	lagoonBuild *lagoonv1beta1.LagoonBuild,
 	jobPod *corev1.Pod,
-	lagoonEnv *corev1.ConfigMap) {
+	lagoonEnv *corev1.ConfigMap,
+) (bool, lagoonv1beta1.LagoonLog) {
 	if r.EnableMQ {
 		condition := "pending"
 		switch jobPod.Status.Phase {
@@ -420,138 +404,12 @@ func (r *LagoonMonitorReconciler) buildStatusLogsToLagoonLogs(ctx context.Contex
 			// if we can't publish the message, set it as a pending message
 			// overwrite whatever is there as these are just current state messages so it doesn't
 			// really matter if we don't smootly transition in what we send back to lagoon
-			r.updateBuildStatusMessage(ctx, lagoonBuild, msg)
-			return
+			return true, msg
 		}
 		// if we are able to publish the message, then we need to remove any pending messages from the resource
 		// and make sure we don't try and publish again
-		r.removeBuildPendingMessageStatus(ctx, lagoonBuild)
 	}
-}
-
-// updateBuildStatusCondition is used to patch the lagoon build with the status conditions for the build, plus any logs
-func (r *LagoonMonitorReconciler) updateBuildStatusCondition(ctx context.Context,
-	lagoonBuild *lagoonv1beta1.LagoonBuild,
-	condition lagoonv1beta1.LagoonBuildConditions,
-	log []byte,
-) error {
-	// set the transition time
-	condition.LastTransitionTime = time.Now().UTC().Format(time.RFC3339)
-	if !helpers.BuildContainsStatus(lagoonBuild.Status.Conditions, condition) {
-		lagoonBuild.Status.Conditions = append(lagoonBuild.Status.Conditions, condition)
-		mergePatch, _ := json.Marshal(map[string]interface{}{
-			"status": map[string]interface{}{
-				"conditions": lagoonBuild.Status.Conditions,
-				"log":        log,
-			},
-		})
-		if err := r.Patch(ctx, lagoonBuild, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
-			return fmt.Errorf("Unable to update status condition: %v", err)
-		}
-	}
-	return nil
-}
-
-// updateBuildStatusMessage this is called if the message queue is unavailable, it stores the message that would be sent in the lagoon build
-func (r *LagoonMonitorReconciler) updateBuildStatusMessage(ctx context.Context,
-	lagoonBuild *lagoonv1beta1.LagoonBuild,
-	statusMessage lagoonv1beta1.LagoonLog,
-) error {
-	// set the transition time
-	mergePatch, _ := json.Marshal(map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"labels": map[string]interface{}{
-				"lagoon.sh/pendingMessages": "true",
-			},
-		},
-		"statusMessages": map[string]interface{}{
-			"statusMessage": statusMessage,
-		},
-	})
-	if err := r.Patch(ctx, lagoonBuild, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
-		return fmt.Errorf("Unable to update status condition: %v", err)
-	}
-	return nil
-}
-
-// updateEnvironmentMessage this is called if the message queue is unavailable, it stores the message that would be sent in the lagoon build
-func (r *LagoonMonitorReconciler) updateEnvironmentMessage(ctx context.Context,
-	lagoonBuild *lagoonv1beta1.LagoonBuild,
-	envMessage lagoonv1beta1.LagoonMessage,
-) error {
-	// set the transition time
-	mergePatch, _ := json.Marshal(map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"labels": map[string]interface{}{
-				"lagoon.sh/pendingMessages": "true",
-			},
-		},
-		"statusMessages": map[string]interface{}{
-			"environmentMessage": envMessage,
-		},
-	})
-	if err := r.Patch(ctx, lagoonBuild, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
-		return fmt.Errorf("Unable to update status condition: %v", err)
-	}
-	return nil
-}
-
-// updateBuildLogMessage this is called if the message queue is unavailable, it stores the message that would be sent in the lagoon build
-func (r *LagoonMonitorReconciler) updateBuildLogMessage(ctx context.Context,
-	lagoonBuild *lagoonv1beta1.LagoonBuild,
-	buildMessage lagoonv1beta1.LagoonLog,
-) error {
-	// set the transition time
-	mergePatch, _ := json.Marshal(map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"labels": map[string]interface{}{
-				"lagoon.sh/pendingMessages": "true",
-			},
-		},
-		"statusMessages": map[string]interface{}{
-			"buildLogMessage": buildMessage,
-		},
-	})
-	if err := r.Patch(ctx, lagoonBuild, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
-		return fmt.Errorf("Unable to update status condition: %v", err)
-	}
-	return nil
-}
-
-// removeBuildPendingMessageStatus purges the status messages from the resource once they are successfully re-sent
-func (r *LagoonMonitorReconciler) removeBuildPendingMessageStatus(ctx context.Context,
-	lagoonBuild *lagoonv1beta1.LagoonBuild,
-) error {
-	// if we have the pending messages label as true, then we want to remove this label and any pending statusmessages
-	// so we can avoid double handling, or an old pending message from being sent after a new pending message
-	if val, ok := lagoonBuild.ObjectMeta.Labels["lagoon.sh/pendingMessages"]; !ok {
-		if val == "true" {
-			mergePatch, _ := json.Marshal(map[string]interface{}{
-				"metadata": map[string]interface{}{
-					"labels": map[string]interface{}{
-						"lagoon.sh/pendingMessages": "false",
-					},
-				},
-				"statusMessages": nil,
-			})
-			if err := r.Patch(ctx, lagoonBuild, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
-				return fmt.Errorf("Unable to update status condition: %v", err)
-			}
-		}
-	}
-	return nil
-}
-
-// updateRunningDeploymentBuildLogs collects logs from running build containers and ships or stores them
-func (r *LagoonMonitorReconciler) updateRunningDeploymentBuildLogs(
-	ctx context.Context,
-	req ctrl.Request,
-	lagoonBuild lagoonv1beta1.LagoonBuild,
-	jobPod corev1.Pod,
-) {
-	opLog := r.Log.WithValues("lagoonmonitor", req.NamespacedName)
-	// send any messages to lagoon message queues
-	r.buildLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &jobPod, r.collectLogs(ctx, req, jobPod))
+	return false, lagoonv1beta1.LagoonLog{}
 }
 
 // updateDeploymentWithLogs collects logs from the build containers and ships or stores them
@@ -560,18 +418,27 @@ func (r *LagoonMonitorReconciler) updateDeploymentWithLogs(
 	req ctrl.Request,
 	lagoonBuild lagoonv1beta1.LagoonBuild,
 	jobPod corev1.Pod,
+	logs []byte,
 	cancel bool,
 ) error {
 	opLog := r.Log.WithValues("lagoonmonitor", req.NamespacedName)
-	var jobCondition lagoonv1beta1.BuildStatusType
+	var buildCondition lagoonv1beta1.BuildStatusType
 	switch jobPod.Status.Phase {
 	case corev1.PodFailed:
-		jobCondition = lagoonv1beta1.BuildStatusFailed
+		buildCondition = lagoonv1beta1.BuildStatusFailed
 	case corev1.PodSucceeded:
-		jobCondition = lagoonv1beta1.BuildStatusComplete
+		buildCondition = lagoonv1beta1.BuildStatusComplete
+	case corev1.PodPending:
+		buildCondition = lagoonv1beta1.BuildStatusPending
+	case corev1.PodRunning:
+		buildCondition = lagoonv1beta1.BuildStatusRunning
 	}
+	collectLogs := true
 	if cancel {
-		jobCondition = lagoonv1beta1.BuildStatusCancelled
+		buildCondition = lagoonv1beta1.BuildStatusCancelled
+		if _, ok := lagoonBuild.ObjectMeta.Labels["lagoon.sh/cancelBuildNoPod"]; ok {
+			collectLogs = false
+		}
 	}
 	// if the build status is Pending or Running
 	// then the jobCondition is Failed, Complete, or Cancelled
@@ -580,7 +447,7 @@ func (r *LagoonMonitorReconciler) updateDeploymentWithLogs(
 	if helpers.ContainsString(
 		helpers.RunningPendingStatus,
 		lagoonBuild.Labels["lagoon.sh/buildStatus"],
-	) {
+	) || cancel {
 		opLog.Info(
 			fmt.Sprintf(
 				"Updating build status for %s to %v",
@@ -588,27 +455,50 @@ func (r *LagoonMonitorReconciler) updateDeploymentWithLogs(
 				jobPod.Status.Phase,
 			),
 		)
-		allContainerLogs := r.collectLogs(ctx, req, jobPod)
-		if cancel {
-			allContainerLogs = append(allContainerLogs, []byte(fmt.Sprintf(`
+		var allContainerLogs []byte
+		var err error
+		if logs == nil {
+			if collectLogs {
+				allContainerLogs, err = r.collectLogs(ctx, req, jobPod)
+				if err == nil {
+					if cancel {
+						allContainerLogs = append(allContainerLogs, []byte(fmt.Sprintf(`
 ========================================
 Build cancelled
 ========================================`))...)
+					}
+				} else {
+					allContainerLogs = []byte(fmt.Sprintf(`
+========================================
+Build %s
+========================================`, buildCondition))
+				}
+			}
+		} else {
+			allContainerLogs = logs
 		}
-		mergePatch, _ := json.Marshal(map[string]interface{}{
+
+		mergeMap := map[string]interface{}{
 			"metadata": map[string]interface{}{
 				"labels": map[string]interface{}{
-					"lagoon.sh/buildStatus": string(jobCondition),
+					"lagoon.sh/buildStatus":  string(buildCondition),
+					"lagoon.sh/buildStarted": "true",
 				},
 			},
-		})
-		if err := r.Patch(ctx, &lagoonBuild, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
-			opLog.Error(err, fmt.Sprintf("Unable to update resource"))
 		}
-		r.updateBuildStatusCondition(ctx, &lagoonBuild, lagoonv1beta1.LagoonBuildConditions{
-			Type:   jobCondition,
-			Status: corev1.ConditionTrue,
-		}, allContainerLogs)
+
+		condition := lagoonv1beta1.LagoonBuildConditions{
+			Type:               buildCondition,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: time.Now().UTC().Format(time.RFC3339),
+		}
+		if !helpers.BuildContainsStatus(lagoonBuild.Status.Conditions, condition) {
+			lagoonBuild.Status.Conditions = append(lagoonBuild.Status.Conditions, condition)
+			mergeMap["status"] = map[string]interface{}{
+				"conditions": lagoonBuild.Status.Conditions,
+				"log":        allContainerLogs,
+			}
+		}
 
 		// get the configmap for lagoon-env so we can use it for updating the deployment in lagoon
 		var lagoonEnv corev1.ConfigMap
@@ -622,16 +512,44 @@ Build cancelled
 			// the updatedeployment function will see it as nil and not bother doing the bits that require the configmap
 			opLog.Info(fmt.Sprintf("There is no configmap %s in namespace %s ", "lagoon-env", jobPod.ObjectMeta.Namespace))
 		}
-		// send any messages to lagoon message queues
-		// update the deployment with the status
-		r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &jobPod, &lagoonEnv)
-		r.updateDeploymentAndEnvironmentTask(ctx, opLog, &lagoonBuild, &jobPod, &lagoonEnv)
-		r.buildLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &jobPod, allContainerLogs)
+
+		// do any message publishing here, and update any pending messages if needed
+		pendingStatus, pendingStatusMessage := r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &jobPod, &lagoonEnv)
+		pendingEnvironment, pendingEnvironmentMessage := r.updateDeploymentAndEnvironmentTask(ctx, opLog, &lagoonBuild, &jobPod, &lagoonEnv)
+		var pendingBuildLog bool
+		var pendingBuildLogMessage lagoonv1beta1.LagoonLog
+		// if the container logs can't be retrieved, we don't want to send any build logs back, as this will nuke
+		// any previously received logs
+		if !strings.Contains(string(allContainerLogs), "unable to retrieve container logs for containerd") {
+			pendingBuildLog, pendingBuildLogMessage = r.buildLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &jobPod, allContainerLogs)
+		}
+		if pendingStatus || pendingEnvironment || pendingBuildLog {
+			mergeMap["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["lagoon.sh/pendingMessages"] = "true"
+			if pendingStatus {
+				mergeMap["statusMessages"].(map[string]interface{})["statusMessage"] = pendingStatusMessage
+			}
+			if pendingEnvironment {
+				mergeMap["statusMessages"].(map[string]interface{})["environmentMessage"] = pendingEnvironmentMessage
+			}
+			if pendingBuildLog {
+				mergeMap["statusMessages"].(map[string]interface{})["buildLogMessage"] = pendingBuildLogMessage
+			}
+		}
+		if !pendingStatus && !pendingEnvironment && !pendingBuildLog {
+			mergeMap["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["lagoon.sh/pendingMessages"] = nil
+			mergeMap["statusMessages"] = nil
+		}
+		mergePatch, _ := json.Marshal(mergeMap)
+		if err := r.Patch(ctx, &lagoonBuild, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
+			opLog.Error(err, fmt.Sprintf("Unable to update resource"))
+		}
 		// just delete the pod
 		// maybe if we move away from using BASH for the kubectl-build-deploy-dind scripts we could handle cancellations better
 		if cancel {
-			if err := r.Delete(ctx, &jobPod); err != nil {
-				return err
+			if err := r.Get(ctx, req.NamespacedName, &jobPod); err == nil {
+				if err := r.Delete(ctx, &jobPod); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/controllers/v1beta1/podmonitor_controller.go
+++ b/controllers/v1beta1/podmonitor_controller.go
@@ -105,12 +105,17 @@ func (r *LagoonMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				opLog.Error(err, fmt.Sprintf("Unable to update the LagoonBuild."))
 			}
 		} else {
-			opLog.Info(fmt.Sprintf("Attempting to update the LagoonBuild with cancellation if required."))
-			// this will update the deployment back to lagoon if it can do so
-			// and should only update if the LagoonBuild is Pending or Running
-			err = r.updateDeploymentWithLogs(ctx, req, lagoonBuild, jobPod, nil, true)
-			if err != nil {
-				opLog.Error(err, fmt.Sprintf("Unable to update the LagoonBuild."))
+			if helpers.ContainsString(
+				helpers.BuildRunningPendingStatus,
+				lagoonBuild.Labels["lagoon.sh/buildStatus"],
+			) {
+				opLog.Info(fmt.Sprintf("Attempting to update the LagoonBuild with cancellation if required."))
+				// this will update the deployment back to lagoon if it can do so
+				// and should only update if the LagoonBuild is Pending or Running
+				err = r.updateDeploymentWithLogs(ctx, req, lagoonBuild, jobPod, nil, true)
+				if err != nil {
+					opLog.Error(err, fmt.Sprintf("Unable to update the LagoonBuild."))
+				}
 			}
 		}
 		// if the update is successful or not, it will just continue on to check for pending builds

--- a/controllers/v1beta1/podmonitor_taskhandlers.go
+++ b/controllers/v1beta1/podmonitor_taskhandlers.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -33,11 +34,10 @@ func (r *LagoonMonitorReconciler) handleTaskMonitor(ctx context.Context, opLog l
 	if cancelTask, ok := jobPod.ObjectMeta.Labels["lagoon.sh/cancelTask"]; ok {
 		cancel, _ := strconv.ParseBool(cancelTask)
 		if cancel {
-			return r.updateTaskWithLogs(ctx, req, lagoonTask, jobPod, cancel)
+			return r.updateTaskWithLogs(ctx, req, lagoonTask, jobPod, nil, cancel)
 		}
 	}
 	if jobPod.Status.Phase == corev1.PodPending {
-		opLog.Info(fmt.Sprintf("Task %s is %v", jobPod.ObjectMeta.Name, jobPod.Status.Phase))
 		for _, container := range jobPod.Status.ContainerStatuses {
 			if container.State.Waiting != nil && helpers.ContainsString(failureStates, container.State.Waiting.Reason) {
 				// if we have a failure state, then fail the task and get the logs from the container
@@ -62,17 +62,23 @@ func (r *LagoonMonitorReconciler) handleTaskMonitor(ctx context.Context, opLog l
 					},
 				}
 				jobPod.Status.ContainerStatuses[0] = state
-				r.updateTaskStatusCondition(ctx, &lagoonTask, lagoonv1beta1.LagoonTaskConditions{
-					Type:   lagoonv1beta1.TaskStatusFailed,
-					Status: corev1.ConditionTrue,
-				}, []byte(container.State.Waiting.Message))
-				// send any messages to lagoon message queues
-				r.taskStatusLogsToLagoonLogs(opLog, &lagoonTask, &jobPod)
-				r.updateLagoonTask(opLog, &lagoonTask, &jobPod)
 				logMsg := fmt.Sprintf("%v: %v", container.State.Waiting.Reason, container.State.Waiting.Message)
-				r.taskLogsToLagoonLogs(opLog, &lagoonTask, &jobPod, []byte(logMsg))
-				return nil
+				return r.updateTaskWithLogs(ctx, req, lagoonTask, jobPod, []byte(logMsg), false)
 			}
+		}
+		return r.updateTaskWithLogs(ctx, req, lagoonTask, jobPod, nil, false)
+	} else if jobPod.Status.Phase == corev1.PodRunning {
+		// if the pod is running and detects a change to the pod (eg, detecting an updated lagoon.sh/taskStep label)
+		// then ship or store the logs
+		// get the task associated to this pod, the information in the resource is used for shipping the logs
+		var lagoonTask lagoonv1beta1.LagoonTask
+		err := r.Get(ctx,
+			types.NamespacedName{
+				Namespace: jobPod.ObjectMeta.Namespace,
+				Name:      jobPod.ObjectMeta.Labels["lagoon.sh/taskName"],
+			}, &lagoonTask)
+		if err != nil {
+			return err
 		}
 	}
 	if jobPod.Status.Phase == corev1.PodFailed || jobPod.Status.Phase == corev1.PodSucceeded {
@@ -85,53 +91,9 @@ func (r *LagoonMonitorReconciler) handleTaskMonitor(ctx context.Context, opLog l
 		if err != nil {
 			return err
 		}
-		var jobCondition lagoonv1beta1.TaskStatusType
-		switch jobPod.Status.Phase {
-		case corev1.PodFailed:
-			jobCondition = lagoonv1beta1.TaskStatusFailed
-		case corev1.PodSucceeded:
-			jobCondition = lagoonv1beta1.TaskStatusComplete
-		}
-		if value, ok := lagoonTask.Labels["lagoon.sh/taskStatus"]; ok {
-			if value == string(lagoonv1beta1.TaskStatusCancelled) {
-				// jobCondition = lagoonv1beta1.TaskStatusCancelled
-				jobCondition = lagoonv1beta1.TaskStatusFailed
-			}
-		}
-		// if the task status doesn't equal the status of the pod
-		// then update the task to reflect the current pod status
-		// we do this so we don't update the status of the task again
-		if lagoonTask.Labels["lagoon.sh/taskStatus"] != string(jobCondition) {
-			opLog.Info(fmt.Sprintf("Task %s %v", jobPod.ObjectMeta.Labels["lagoon.sh/taskName"], jobPod.Status.Phase))
-			// set the status to the task condition
-			lagoonTask.Labels["lagoon.sh/taskStatus"] = string(jobCondition)
-			if err := r.Update(ctx, &lagoonTask); err != nil {
-				return err
-			}
-			allContainerLogs := r.collectLogs(ctx, req, jobPod)
-			r.updateTaskStatusCondition(ctx, &lagoonTask,
-				lagoonv1beta1.LagoonTaskConditions{
-					Type:   jobCondition,
-					Status: corev1.ConditionTrue,
-				},
-				allContainerLogs,
-			)
-			// send any messages to lagoon message queues
-			// update the deployment with the status
-			r.taskStatusLogsToLagoonLogs(opLog, &lagoonTask, &jobPod)
-			r.updateLagoonTask(opLog, &lagoonTask, &jobPod)
-			r.taskLogsToLagoonLogs(opLog, &lagoonTask, &jobPod, allContainerLogs)
-		}
-		return nil
 	}
 	// if it isn't pending, failed, or complete, it will be running, we should tell lagoon
-	opLog.Info(fmt.Sprintf("Task %s is %v", jobPod.ObjectMeta.Labels["lagoon.sh/taskName"], jobPod.Status.Phase))
-	// send any messages to lagoon message queues
-	r.taskStatusLogsToLagoonLogs(opLog, &lagoonTask, &jobPod)
-	r.updateLagoonTask(opLog, &lagoonTask, &jobPod)
-	// send the logs to lagoon so that tasks can receive possibly more frequent logs like builds
-	r.taskLogsToLagoonLogs(opLog, &lagoonTask, &jobPod, r.collectLogs(ctx, req, jobPod))
-	return nil
+	return r.updateTaskWithLogs(ctx, req, lagoonTask, jobPod, nil, false)
 }
 
 // taskLogsToLagoonLogs sends the task logs to the lagoon-logs message queue
@@ -140,7 +102,7 @@ func (r *LagoonMonitorReconciler) taskLogsToLagoonLogs(opLog logr.Logger,
 	lagoonTask *lagoonv1beta1.LagoonTask,
 	jobPod *corev1.Pod,
 	logs []byte,
-) {
+) (bool, lagoonv1beta1.LagoonLog) {
 	if r.EnableMQ {
 		condition := "pending"
 		switch jobPod.Status.Phase {
@@ -183,13 +145,12 @@ Logs on pod %s
 			// if we can't publish the message, set it as a pending message
 			// overwrite whatever is there as these are just current state messages so it doesn't
 			// really matter if we don't smootly transition in what we send back to lagoon
-			r.updateTaskStatusMessage(context.Background(), lagoonTask, msg)
-			return
+			return true, msg
 		}
 		// if we are able to publish the message, then we need to remove any pending messages from the resource
 		// and make sure we don't try and publish again
-		r.removeTaskPendingMessageStatus(context.Background(), lagoonTask)
 	}
+	return false, lagoonv1beta1.LagoonLog{}
 }
 
 // updateLagoonTask sends the status of the task and deployment to the controllerhandler message queue in lagoon,
@@ -197,7 +158,7 @@ Logs on pod %s
 func (r *LagoonMonitorReconciler) updateLagoonTask(opLog logr.Logger,
 	lagoonTask *lagoonv1beta1.LagoonTask,
 	jobPod *corev1.Pod,
-) {
+) (bool, lagoonv1beta1.LagoonMessage) {
 	namespace := helpers.GenerateNamespaceName(
 		lagoonTask.Spec.Project.NamespacePattern, // the namespace pattern or `openshiftProjectPattern` from Lagoon is never received by the controller
 		lagoonTask.Spec.Environment.Name,
@@ -272,20 +233,19 @@ func (r *LagoonMonitorReconciler) updateLagoonTask(opLog logr.Logger,
 			// if we can't publish the message, set it as a pending message
 			// overwrite whatever is there as these are just current state messages so it doesn't
 			// really matter if we don't smootly transition in what we send back to lagoon
-			r.updateTaskEnvironmentMessage(context.Background(), lagoonTask, msg)
-			return
+			return true, msg
 		}
 		// if we are able to publish the message, then we need to remove any pending messages from the resource
 		// and make sure we don't try and publish again
-		r.removeTaskPendingMessageStatus(context.Background(), lagoonTask)
 	}
+	return false, lagoonv1beta1.LagoonMessage{}
 }
 
 // taskStatusLogsToLagoonLogs sends the logs to lagoon-logs message queue, used for general messaging
 func (r *LagoonMonitorReconciler) taskStatusLogsToLagoonLogs(opLog logr.Logger,
 	lagoonTask *lagoonv1beta1.LagoonTask,
 	jobPod *corev1.Pod,
-) {
+) (bool, lagoonv1beta1.LagoonLog) {
 	if r.EnableMQ {
 		condition := "pending"
 		switch jobPod.Status.Phase {
@@ -332,98 +292,12 @@ func (r *LagoonMonitorReconciler) taskStatusLogsToLagoonLogs(opLog logr.Logger,
 			// if we can't publish the message, set it as a pending message
 			// overwrite whatever is there as these are just current state messages so it doesn't
 			// really matter if we don't smootly transition in what we send back to lagoon
-			r.updateTaskStatusMessage(context.Background(), lagoonTask, msg)
-			return
+			return true, msg
 		}
 		// if we are able to publish the message, then we need to remove any pending messages from the resource
 		// and make sure we don't try and publish again
-		r.removeTaskPendingMessageStatus(context.Background(), lagoonTask)
 	}
-}
-
-// updateTaskStatusCondition is used to patch the lagoon task with the status conditions for the task, plus any logs
-func (r *LagoonMonitorReconciler) updateTaskStatusCondition(ctx context.Context,
-	lagoonTask *lagoonv1beta1.LagoonTask,
-	condition lagoonv1beta1.LagoonTaskConditions, log []byte) error {
-	// set the transition time
-	condition.LastTransitionTime = time.Now().UTC().Format(time.RFC3339)
-	if !helpers.TaskContainsStatus(lagoonTask.Status.Conditions, condition) {
-		lagoonTask.Status.Conditions = append(lagoonTask.Status.Conditions, condition)
-		mergePatch, _ := json.Marshal(map[string]interface{}{
-			"status": map[string]interface{}{
-				"conditions": lagoonTask.Status.Conditions,
-				"log":        log,
-			},
-		})
-		if err := r.Patch(ctx, lagoonTask, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
-			return fmt.Errorf("Unable to update status condition: %v", err)
-		}
-	}
-	return nil
-}
-
-// updateTaskEnvironmentMessage this is called if the message queue is unavailable, it stores the message that would be sent in the lagoon task
-func (r *LagoonMonitorReconciler) updateTaskEnvironmentMessage(ctx context.Context,
-	lagoonTask *lagoonv1beta1.LagoonTask,
-	envMessage lagoonv1beta1.LagoonMessage) error {
-	// set the transition time
-	mergePatch, _ := json.Marshal(map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"labels": map[string]interface{}{
-				"lagoon.sh/pendingMessages": "true",
-			},
-		},
-		"statusMessages": map[string]interface{}{
-			"environmentMessage": envMessage,
-		},
-	})
-	if err := r.Patch(ctx, lagoonTask, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
-		return fmt.Errorf("Unable to update status condition: %v", err)
-	}
-	return nil
-}
-
-// updateTaskStatusMessage this is called if the message queue is unavailable, it stores the message that would be sent in the lagoon task
-func (r *LagoonMonitorReconciler) updateTaskStatusMessage(ctx context.Context,
-	lagoonTask *lagoonv1beta1.LagoonTask,
-	statusMessage lagoonv1beta1.LagoonLog) error {
-	// set the transition time
-	mergePatch, _ := json.Marshal(map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"labels": map[string]interface{}{
-				"lagoon.sh/pendingMessages": "true",
-			},
-		},
-		"statusMessages": map[string]interface{}{
-			"statusMessage": statusMessage,
-		},
-	})
-	if err := r.Patch(ctx, lagoonTask, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
-		return fmt.Errorf("Unable to update status condition: %v", err)
-	}
-	return nil
-}
-
-// removeTaskPendingMessageStatus purges the status messages from the resource once they are successfully re-sent
-func (r *LagoonMonitorReconciler) removeTaskPendingMessageStatus(ctx context.Context, lagoonTask *lagoonv1beta1.LagoonTask) error {
-	// if we have the pending messages label as true, then we want to remove this label and any pending statusmessages
-	// so we can avoid double handling, or an old pending message from being sent after a new pending message
-	if val, ok := lagoonTask.ObjectMeta.Labels["lagoon.sh/pendingMessages"]; !ok {
-		if val == "true" {
-			mergePatch, _ := json.Marshal(map[string]interface{}{
-				"metadata": map[string]interface{}{
-					"labels": map[string]interface{}{
-						"lagoon.sh/pendingMessages": "false",
-					},
-				},
-				"statusMessages": nil,
-			})
-			if err := r.Patch(ctx, lagoonTask, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
-				return fmt.Errorf("Unable to update status condition: %v", err)
-			}
-		}
-	}
-	return nil
+	return false, lagoonv1beta1.LagoonLog{}
 }
 
 // updateTaskWithLogs collects logs from the task containers and ships or stores them
@@ -432,6 +306,7 @@ func (r *LagoonMonitorReconciler) updateTaskWithLogs(
 	req ctrl.Request,
 	lagoonTask lagoonv1beta1.LagoonTask,
 	jobPod corev1.Pod,
+	logs []byte,
 	cancel bool,
 ) error {
 	opLog := r.Log.WithValues("lagoonmonitor", req.NamespacedName)
@@ -441,7 +316,12 @@ func (r *LagoonMonitorReconciler) updateTaskWithLogs(
 		jobCondition = lagoonv1beta1.TaskStatusFailed
 	case corev1.PodSucceeded:
 		jobCondition = lagoonv1beta1.TaskStatusComplete
+	case corev1.PodPending:
+		jobCondition = lagoonv1beta1.TaskStatusPending
+	case corev1.PodRunning:
+		jobCondition = lagoonv1beta1.TaskStatusRunning
 	}
+	collectLogs := true
 	if cancel {
 		jobCondition = lagoonv1beta1.TaskStatusCancelled
 	}
@@ -452,7 +332,7 @@ func (r *LagoonMonitorReconciler) updateTaskWithLogs(
 	if helpers.ContainsString(
 		helpers.TaskRunningPendingStatus,
 		lagoonTask.Labels["lagoon.sh/taskStatus"],
-	) {
+	) || cancel {
 		opLog.Info(
 			fmt.Sprintf(
 				"Updating task status for %s to %v",
@@ -463,33 +343,82 @@ func (r *LagoonMonitorReconciler) updateTaskWithLogs(
 		// grab all the logs from the containers in the task pod and just merge them all together
 		// we only have 1 container at the moment in a taskpod anyway so it doesn't matter
 		// if we do move to multi container tasks, then worry about it
-		allContainerLogs := r.collectLogs(ctx, req, jobPod)
-		if cancel {
-			allContainerLogs = append(allContainerLogs, []byte(fmt.Sprintf(`
+		var allContainerLogs []byte
+		var err error
+		if logs == nil {
+			if collectLogs {
+				allContainerLogs, err = r.collectLogs(ctx, req, jobPod)
+				if err == nil {
+					if cancel {
+						allContainerLogs = append(allContainerLogs, []byte(fmt.Sprintf(`
 ========================================
 Task cancelled
 ========================================`))...)
+					}
+				} else {
+					allContainerLogs = []byte(fmt.Sprintf(`
+========================================
+Task %s
+========================================`, jobCondition))
+				}
+			}
+		} else {
+			allContainerLogs = logs
 		}
-		mergePatch, _ := json.Marshal(map[string]interface{}{
+
+		mergeMap := map[string]interface{}{
 			"metadata": map[string]interface{}{
 				"labels": map[string]interface{}{
 					"lagoon.sh/taskStatus": string(jobCondition),
 				},
 			},
-		})
-		lagoonTask.ObjectMeta.Labels["lagoon.sh/taskStatus"] = string(jobCondition)
+		}
+
+		condition := lagoonv1beta1.LagoonTaskConditions{
+			Type:               jobCondition,
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: time.Now().UTC().Format(time.RFC3339),
+		}
+		if !helpers.TaskContainsStatus(lagoonTask.Status.Conditions, condition) {
+			lagoonTask.Status.Conditions = append(lagoonTask.Status.Conditions, condition)
+			mergeMap["status"] = map[string]interface{}{
+				"conditions": lagoonTask.Status.Conditions,
+				"log":        allContainerLogs,
+			}
+		}
+
+		// send any messages to lagoon message queues
+		// update the deployment with the status
+		pendingStatus, pendingStatusMessage := r.taskStatusLogsToLagoonLogs(opLog, &lagoonTask, &jobPod)
+		pendingEnvironment, pendingEnvironmentMessage := r.updateLagoonTask(opLog, &lagoonTask, &jobPod)
+		var pendingTaskLog bool
+		var pendingTaskLogMessage lagoonv1beta1.LagoonLog
+		// if the container logs can't be retrieved, we don't want to send any build logs back, as this will nuke
+		// any previously received logs
+		if !strings.Contains(string(allContainerLogs), "unable to retrieve container logs for containerd") {
+			pendingTaskLog, pendingTaskLogMessage = r.taskLogsToLagoonLogs(opLog, &lagoonTask, &jobPod, allContainerLogs)
+		}
+
+		if pendingStatus || pendingEnvironment || pendingTaskLog {
+			mergeMap["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["lagoon.sh/pendingMessages"] = "true"
+			if pendingStatus {
+				mergeMap["statusMessages"].(map[string]interface{})["statusMessage"] = pendingStatusMessage
+			}
+			if pendingEnvironment {
+				mergeMap["statusMessages"].(map[string]interface{})["environmentMessage"] = pendingEnvironmentMessage
+			}
+			if pendingTaskLog {
+				mergeMap["statusMessages"].(map[string]interface{})["taskLogMessage"] = pendingTaskLogMessage
+			}
+		}
+		if !pendingStatus && !pendingEnvironment && !pendingTaskLog {
+			mergeMap["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["lagoon.sh/pendingMessages"] = nil
+			mergeMap["statusMessages"] = nil
+		}
+		mergePatch, _ := json.Marshal(mergeMap)
 		if err := r.Patch(ctx, &lagoonTask, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
 			opLog.Error(err, fmt.Sprintf("Unable to update resource"))
 		}
-		r.updateTaskStatusCondition(ctx, &lagoonTask, lagoonv1beta1.LagoonTaskConditions{
-			Type:   jobCondition,
-			Status: corev1.ConditionTrue,
-		}, allContainerLogs)
-		// send any messages to lagoon message queues
-		// update the deployment with the status
-		r.taskStatusLogsToLagoonLogs(opLog, &lagoonTask, &jobPod)
-		r.updateLagoonTask(opLog, &lagoonTask, &jobPod)
-		r.taskLogsToLagoonLogs(opLog, &lagoonTask, &jobPod, allContainerLogs)
 		// just delete the pod
 		if cancel {
 			if err := r.Delete(ctx, &jobPod); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mittwald/goharbor-client/v5 v5.0.3
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
-	github.com/openshift/api v3.9.0+incompatible
+	github.com/prometheus/client_golang v1.11.0
 	github.com/xhit/go-str2duration/v2 v2.0.0
 	gopkg.in/matryer/try.v1 v1.0.0-20150601225556-312d2599e12e
 	gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5
@@ -75,7 +75,6 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -883,8 +883,6 @@ github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
-github.com/openshift/api v3.9.0+incompatible h1:fJ/KsefYuZAjmrr3+5U9yZIZbTOpVkDDLDLFresAeYs=
-github.com/openshift/api v3.9.0+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/handlers/message_queue.go
+++ b/handlers/message_queue.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cheshir/go-mq"
+	"github.com/go-logr/logr"
 	lagoonv1beta1 "github.com/uselagoon/remote-controller/apis/lagoon/v1beta1"
 	"github.com/uselagoon/remote-controller/internal/helpers"
 	"gopkg.in/matryer/try.v1"
@@ -500,7 +501,13 @@ func (h *Messaging) Publish(queue string, message []byte) error {
 func (h *Messaging) GetPendingMessages() {
 	opLog := ctrl.Log.WithName("handlers").WithName("PendingMessages")
 	ctx := context.Background()
-	opLog.Info(fmt.Sprintf("Checking pending messages across all namespaces"))
+	opLog.Info(fmt.Sprintf("Checking pending build messages across all namespaces"))
+	h.pendingBuildLogMessages(ctx, opLog)
+	opLog.Info(fmt.Sprintf("Checking pending task messages across all namespaces"))
+	h.pendingTaskLogMessages(ctx, opLog)
+}
+
+func (h *Messaging) pendingBuildLogMessages(ctx context.Context, opLog logr.Logger) {
 	pendingMsgs := &lagoonv1beta1.LagoonBuildList{}
 	listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
 		client.MatchingLabels(map[string]string{
@@ -522,24 +529,24 @@ func (h *Messaging) GetPendingMessages() {
 			break
 		}
 		opLog.Info(fmt.Sprintf("LagoonBuild %s has pending messages, attempting to re-send", build.ObjectMeta.Name))
-		statusBytes, _ := json.Marshal(build.StatusMessages.StatusMessage)
-		logBytes, _ := json.Marshal(build.StatusMessages.BuildLogMessage)
-		envBytes, _ := json.Marshal(build.StatusMessages.EnvironmentMessage)
 
 		// try to re-publish message or break and try the next build with pending message
 		if build.StatusMessages.StatusMessage != nil {
+			statusBytes, _ := json.Marshal(build.StatusMessages.StatusMessage)
 			if err := h.Publish("lagoon-logs", statusBytes); err != nil {
 				opLog.Error(err, fmt.Sprintf("Unable to publush message"))
 				break
 			}
 		}
 		if build.StatusMessages.BuildLogMessage != nil {
+			logBytes, _ := json.Marshal(build.StatusMessages.BuildLogMessage)
 			if err := h.Publish("lagoon-logs", logBytes); err != nil {
 				opLog.Error(err, fmt.Sprintf("Unable to publush message"))
 				break
 			}
 		}
 		if build.StatusMessages.EnvironmentMessage != nil {
+			envBytes, _ := json.Marshal(build.StatusMessages.EnvironmentMessage)
 			if err := h.Publish("lagoon-tasks:controller", envBytes); err != nil {
 				opLog.Error(err, fmt.Sprintf("Unable to publush message"))
 				break
@@ -557,6 +564,70 @@ func (h *Messaging) GetPendingMessages() {
 			"statusMessages": nil,
 		})
 		if err := h.Client.Patch(ctx, &build, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
+			opLog.Error(err, fmt.Sprintf("Unable to update status condition"))
+			break
+		}
+	}
+	return
+}
+
+func (h *Messaging) pendingTaskLogMessages(ctx context.Context, opLog logr.Logger) {
+	pendingMsgs := &lagoonv1beta1.LagoonTaskList{}
+	listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
+		client.MatchingLabels(map[string]string{
+			"lagoon.sh/pendingMessages": "true",
+			"lagoon.sh/controller":      h.ControllerNamespace,
+		}),
+	})
+	if err := h.Client.List(ctx, pendingMsgs, listOption); err != nil {
+		opLog.Error(err, fmt.Sprintf("Unable to list LagoonBuilds, there may be none or something went wrong"))
+		return
+	}
+	for _, task := range pendingMsgs.Items {
+		// get the latest resource in case it has been updated since the loop started
+		if err := h.Client.Get(ctx, types.NamespacedName{
+			Name:      task.ObjectMeta.Name,
+			Namespace: task.ObjectMeta.Namespace,
+		}, &task); err != nil {
+			opLog.Error(err, fmt.Sprintf("Unable to get LagoonBuild, something went wrong"))
+			break
+		}
+		opLog.Info(fmt.Sprintf("LagoonTasl %s has pending messages, attempting to re-send", task.ObjectMeta.Name))
+
+		// try to re-publish message or break and try the next build with pending message
+		if task.StatusMessages.StatusMessage != nil {
+			statusBytes, _ := json.Marshal(task.StatusMessages.StatusMessage)
+			if err := h.Publish("lagoon-logs", statusBytes); err != nil {
+				opLog.Error(err, fmt.Sprintf("Unable to publush message"))
+				break
+			}
+		}
+		if task.StatusMessages.TaskLogMessage != nil {
+			taskLogBytes, _ := json.Marshal(task.StatusMessages.TaskLogMessage)
+			if err := h.Publish("lagoon-logs", taskLogBytes); err != nil {
+				opLog.Error(err, fmt.Sprintf("Unable to publush message"))
+				break
+			}
+		}
+		if task.StatusMessages.EnvironmentMessage != nil {
+			envBytes, _ := json.Marshal(task.StatusMessages.EnvironmentMessage)
+			if err := h.Publish("lagoon-tasks:controller", envBytes); err != nil {
+				opLog.Error(err, fmt.Sprintf("Unable to publush message"))
+				break
+			}
+		}
+		// if we managed to send all the pending messages, then update the resource to remove the pending state
+		// so we don't send the same message multiple times
+		opLog.Info(fmt.Sprintf("Sent pending messages for LagoonTask %s", task.ObjectMeta.Name))
+		mergePatch, _ := json.Marshal(map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"labels": map[string]interface{}{
+					"lagoon.sh/pendingMessages": "false",
+				},
+			},
+			"statusMessages": nil,
+		})
+		if err := h.Client.Patch(ctx, &task, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
 			opLog.Error(err, fmt.Sprintf("Unable to update status condition"))
 			break
 		}

--- a/handlers/misctask_handler.go
+++ b/handlers/misctask_handler.go
@@ -41,6 +41,7 @@ func (h *Messaging) CancelBuild(namespace string, jobSpec *lagoonv1beta1.LagoonT
 		// as there is no build pod, but there is a lagoon build resource
 		// update it to cancelled so that the controller doesn't try to run it
 		lagoonBuild.ObjectMeta.Labels["lagoon.sh/buildStatus"] = string(lagoonv1beta1.BuildStatusCancelled)
+		lagoonBuild.ObjectMeta.Labels["lagoon.sh/cancelBuildNoPod"] = "true"
 		if err := h.Client.Update(context.Background(), &lagoonBuild); err != nil {
 			opLog.Error(err,
 				fmt.Sprintf(

--- a/handlers/misctask_handler.go
+++ b/handlers/misctask_handler.go
@@ -24,6 +24,10 @@ func (h *Messaging) CancelBuild(namespace string, jobSpec *lagoonv1beta1.LagoonT
 		Name:      jobSpec.Misc.Name,
 		Namespace: namespace,
 	}, &jobPod); err != nil {
+		opLog.Info(fmt.Sprintf(
+			"Unable to find build pod %s to cancel it. Checking to see if LagoonBuild exists.",
+			jobSpec.Misc.Name,
+		))
 		// since there was no build pod, check for the lagoon build resource
 		var lagoonBuild lagoonv1beta1.LagoonBuild
 		if err := h.Client.Get(context.Background(), types.NamespacedName{

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -42,17 +42,6 @@ var (
 		string(lagoonv1beta1.TaskStatusComplete),
 		string(lagoonv1beta1.TaskStatusCancelled),
 	}
-	// RunningPendingStatus .
-	RunningPendingStatus = []string{
-		string(lagoonv1beta1.BuildStatusPending),
-		string(lagoonv1beta1.BuildStatusRunning),
-	}
-	// CompletedCancelledFailedStatus .
-	CompletedCancelledFailedStatus = []string{
-		string(lagoonv1beta1.BuildStatusFailed),
-		string(lagoonv1beta1.BuildStatusComplete),
-		string(lagoonv1beta1.BuildStatusCancelled),
-	}
 )
 
 const (

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -236,13 +236,13 @@ func CancelExtraBuilds(ctx context.Context, r client.Client, opLog logr.Logger, 
 	if err := r.List(ctx, pendingBuilds, listOption); err != nil {
 		return fmt.Errorf("Unable to list builds in the namespace, there may be none or something went wrong: %v", err)
 	}
-	opLog.Info(fmt.Sprintf("There are %v Pending builds", len(pendingBuilds.Items)))
-	// if we have any pending builds, then grab the latest one and make it running
-	// if there are any other pending builds, cancel them so only the latest one runs
-	sort.Slice(pendingBuilds.Items, func(i, j int) bool {
-		return pendingBuilds.Items[i].ObjectMeta.CreationTimestamp.After(pendingBuilds.Items[j].ObjectMeta.CreationTimestamp.Time)
-	})
 	if len(pendingBuilds.Items) > 0 {
+		opLog.Info(fmt.Sprintf("There are %v Pending builds", len(pendingBuilds.Items)))
+		// if we have any pending builds, then grab the latest one and make it running
+		// if there are any other pending builds, cancel them so only the latest one runs
+		sort.Slice(pendingBuilds.Items, func(i, j int) bool {
+			return pendingBuilds.Items[i].ObjectMeta.CreationTimestamp.After(pendingBuilds.Items[j].ObjectMeta.CreationTimestamp.Time)
+		})
 		for idx, pBuild := range pendingBuilds.Items {
 			pendingBuild := pBuild.DeepCopy()
 			if idx == 0 {

--- a/main.go
+++ b/main.go
@@ -242,7 +242,7 @@ func main() {
 	flag.StringVar(&buildPodCleanUpCron, "build-pod-cleanup-cron", "0 * * * *",
 		"The cron definition for how often to run the build pod cleanup.")
 	flag.BoolVar(&buildsCleanUpEnable, "enable-lagoonbuilds-cleanup", true, "Flag to enable lagoonbuild resources cleanup.")
-	flag.StringVar(&buildsCleanUpCron, "lagoonbuilds-cleanup-cron", "0 * * * *",
+	flag.StringVar(&buildsCleanUpCron, "lagoonbuilds-cleanup-cron", "30 * * * *",
 		"The cron definition for how often to run the lagoonbuild resources cleanup.")
 	flag.IntVar(&buildsToKeep, "num-builds-to-keep", 1, "The number of lagoonbuild resources to keep per namespace.")
 	flag.IntVar(&buildPodsToKeep, "num-build-pods-to-keep", 1, "The number of build pods to keep per namespace.")

--- a/main.go
+++ b/main.go
@@ -169,7 +169,7 @@ func main() {
 		"The retry interval for rabbitmq.")
 	flag.StringVar(&leaderElectionID, "leader-election-id", "lagoon-builddeploy-leader-election-helper",
 		"The ID to use for leader election.")
-	flag.StringVar(&pendingMessageCron, "pending-message-cron", "*/5 * * * *",
+	flag.StringVar(&pendingMessageCron, "pending-message-cron", "15,45 * * * *",
 		"The cron definition for pending messages.")
 	flag.IntVar(&startupConnectionAttempts, "startup-connection-attempts", 10,
 		"The number of startup attempts before exiting.")

--- a/main.go
+++ b/main.go
@@ -17,8 +17,10 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"flag"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strconv"
@@ -54,6 +56,7 @@ var (
 	lagoonAPIHost    string
 	lagoonSSHHost    string
 	lagoonSSHPort    string
+	tlsSkipVerify    bool
 )
 
 func init() {
@@ -253,6 +256,8 @@ func main() {
 	flag.IntVar(&taskPodsToKeep, "num-task-pods-to-keep", 1, "The number of task pods to keep per namespace.")
 	flag.BoolVar(&lffBackupWeeklyRandom, "lagoon-feature-flag-backup-weekly-random", false,
 		"Tells Lagoon whether or not to use the \"weekly-random\" schedule for k8up backups.")
+
+	flag.BoolVar(&tlsSkipVerify, "skip-tls-verify", false, "Flag to skip tls verification for http clients (harbor).")
 
 	flag.IntVar(&nativeCronPodMinFrequency, "native-cron-pod-min-frequency", 15, "The number of lagoontask resources to keep per namespace.")
 
@@ -771,4 +776,10 @@ func getEnvBool(key string, fallback bool) bool {
 		return rVal
 	}
 	return fallback
+}
+
+func init() {
+	if tlsSkipVerify {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
 }


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Major refactoring around patching operations to try and solve some issues.

Notably, if builds are cancelled via Lagoon, but a build that is complete or failed already in the remote, then remote-controller will attempt to retain this when responding back to Lagoon, otherwise it will fall back to cancelling.

# Closing issues

closes #75
closes #121 