### PR TITLE
delete jobs in the namespace too to prevent hold ups

### DIFF
--- a/controllers/messenger/queues.go
+++ b/controllers/messenger/queues.go
@@ -283,6 +283,10 @@ func (h *Messaging) Consumer(targetName string) { //error {
 						message.Ack(false) // ack to remove from queue
 						return
 					}
+					if del := h.DeleteJobs(ctx, opLog.WithName("DeleteJobs"), ns, project, branch); del == false {
+						message.Ack(false) // ack to remove from queue
+						return
+					}
 					if del := h.DeletePVCs(ctx, opLog.WithName("DeletePVCs"), ns, project, branch); del == false {
 						message.Ack(false) // ack to remove from queue
 						return


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

When volumes are deleted, but there is a Job that had mounted it, the namespace is never deleted due to the Job holding the volume. This adds a step to clean up potential Jobs that may be holding a volume.

# Closing issues

closes #139 