### PR TITLE
feat: inject lagoon api/ssh config into builds

### DIFF
--- a/controllers/v1beta1/build_controller.go
+++ b/controllers/v1beta1/build_controller.go
@@ -73,6 +73,7 @@ type LagoonBuildReconciler struct {
 	NativeCronPodMinFrequency        int
 	LagoonTargetName                 string
 	LagoonFeatureFlags               map[string]string
+	LagoonAPIConfiguration           LagoonAPIConfiguration
 	ProxyConfig                      ProxyConfig
 }
 

--- a/controllers/v1beta1/build_helpers.go
+++ b/controllers/v1beta1/build_helpers.go
@@ -510,6 +510,20 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 			Name:  "NATIVE_CRON_POD_MINIMUM_FREQUENCY",
 			Value: strconv.Itoa(r.NativeCronPodMinFrequency),
 		},
+		// add the API and SSH endpoint configuration to environments
+		{
+			Name:  "LAGOON_CONFIG_API_HOST",
+			Value: r.LagoonAPIConfiguration.APIHost,
+		},
+		{
+			Name:  "LAGOON_CONFIG_SSH_HOST",
+			Value: r.LagoonAPIConfiguration.SSHHost,
+		},
+		{
+			Name:  "LAGOON_CONFIG_SSH_PORT",
+			Value: r.LagoonAPIConfiguration.SSHPort,
+		},
+		// in the future, the SSH_HOST and SSH_PORT could also have regional variants
 	}
 	// add proxy variables to builds if they are defined
 	if r.ProxyConfig.HTTPProxy != "" {

--- a/controllers/v1beta1/task_controller.go
+++ b/controllers/v1beta1/task_controller.go
@@ -39,19 +39,19 @@ import (
 // LagoonTaskReconciler reconciles a LagoonTask object
 type LagoonTaskReconciler struct {
 	client.Client
-	Log                   logr.Logger
-	Scheme                *runtime.Scheme
-	ControllerNamespace   string
-	NamespacePrefix       string
-	RandomNamespacePrefix bool
-	TaskSettings          LagoonTaskSettings
-	EnableDebug           bool
-	LagoonTargetName      string
-	ProxyConfig           ProxyConfig
+	Log                    logr.Logger
+	Scheme                 *runtime.Scheme
+	ControllerNamespace    string
+	NamespacePrefix        string
+	RandomNamespacePrefix  bool
+	LagoonAPIConfiguration LagoonAPIConfiguration
+	EnableDebug            bool
+	LagoonTargetName       string
+	ProxyConfig            ProxyConfig
 }
 
-// LagoonTaskSettings is for the settings for task API/SSH host/ports
-type LagoonTaskSettings struct {
+// LagoonAPIConfiguration is for the settings for task API/SSH host/ports
+type LagoonAPIConfiguration struct {
 	APIHost string
 	SSHHost string
 	SSHPort string
@@ -149,6 +149,7 @@ func (r *LagoonTaskReconciler) getTaskPodDeployment(ctx context.Context, lagoonT
 				hasService = true
 				// grab the container
 				for idx, depCon := range dep.Spec.Template.Spec.Containers {
+					// --- deprecate these at some point in favor of the `LAGOON_CONFIG_X` variants
 					dep.Spec.Template.Spec.Containers[idx].Env = append(dep.Spec.Template.Spec.Containers[idx].Env, corev1.EnvVar{
 						Name:  "TASK_API_HOST",
 						Value: r.getTaskValue(lagoonTask, "TASK_API_HOST"),
@@ -161,6 +162,21 @@ func (r *LagoonTaskReconciler) getTaskPodDeployment(ctx context.Context, lagoonT
 						Name:  "TASK_SSH_PORT",
 						Value: r.getTaskValue(lagoonTask, "TASK_SSH_PORT"),
 					})
+					// ^^ ---
+					// add the API and SSH endpoint configuration to environments
+					dep.Spec.Template.Spec.Containers[idx].Env = append(dep.Spec.Template.Spec.Containers[idx].Env, corev1.EnvVar{
+						Name:  "LAGOON_CONFIG_API_HOST",
+						Value: r.getTaskValue(lagoonTask, "LAGOON_CONFIG_API_HOST"),
+					})
+					dep.Spec.Template.Spec.Containers[idx].Env = append(dep.Spec.Template.Spec.Containers[idx].Env, corev1.EnvVar{
+						Name:  "LAGOON_CONFIG_SSH_HOST",
+						Value: r.getTaskValue(lagoonTask, "LAGOON_CONFIG_SSH_HOST"),
+					})
+					dep.Spec.Template.Spec.Containers[idx].Env = append(dep.Spec.Template.Spec.Containers[idx].Env, corev1.EnvVar{
+						Name:  "LAGOON_CONFIG_SSH_PORT",
+						Value: r.getTaskValue(lagoonTask, "LAGOON_CONFIG_SSH_PORT"),
+					})
+					// in the future, the SSH_HOST and SSH_PORT could also have regional variants
 					dep.Spec.Template.Spec.Containers[idx].Env = append(dep.Spec.Template.Spec.Containers[idx].Env, corev1.EnvVar{
 						Name:  "TASK_DATA_ID",
 						Value: lagoonTask.Spec.Task.ID,
@@ -495,17 +511,32 @@ func (r *LagoonTaskReconciler) getTaskValue(lagoonTask *lagoonv1beta1.LagoonTask
 	switch value {
 	case "TASK_API_HOST":
 		if lagoonTask.Spec.Task.APIHost == "" {
-			return r.TaskSettings.APIHost
+			return r.LagoonAPIConfiguration.APIHost
 		}
 		return lagoonTask.Spec.Task.APIHost
 	case "TASK_SSH_HOST":
 		if lagoonTask.Spec.Task.SSHHost == "" {
-			return r.TaskSettings.SSHHost
+			return r.LagoonAPIConfiguration.SSHHost
 		}
 		return lagoonTask.Spec.Task.SSHHost
 	case "TASK_SSH_PORT":
 		if lagoonTask.Spec.Task.SSHPort == "" {
-			return r.TaskSettings.SSHPort
+			return r.LagoonAPIConfiguration.SSHPort
+		}
+		return lagoonTask.Spec.Task.SSHPort
+	case "LAGOON_CONFIG_API_HOST":
+		if lagoonTask.Spec.Task.APIHost == "" {
+			return r.LagoonAPIConfiguration.APIHost
+		}
+		return lagoonTask.Spec.Task.APIHost
+	case "LAGOON_CONFIG_SSH_HOST":
+		if lagoonTask.Spec.Task.SSHHost == "" {
+			return r.LagoonAPIConfiguration.SSHHost
+		}
+		return lagoonTask.Spec.Task.SSHHost
+	case "LAGOON_CONFIG_SSH_PORT":
+		if lagoonTask.Spec.Task.SSHPort == "" {
+			return r.LagoonAPIConfiguration.SSHPort
 		}
 		return lagoonTask.Spec.Task.SSHPort
 	}

--- a/main.go
+++ b/main.go
@@ -710,6 +710,11 @@ func main() {
 		NativeCronPodMinFrequency:        nativeCronPodMinFrequency,
 		LagoonTargetName:                 lagoonTargetName,
 		LagoonFeatureFlags:               helpers.GetLagoonFeatureFlags(),
+		LagoonAPIConfiguration: lagoonv1beta1ctrl.LagoonAPIConfiguration{
+			APIHost: lagoonAPIHost,
+			SSHHost: lagoonSSHHost,
+			SSHPort: lagoonSSHPort,
+		},
 		ProxyConfig: lagoonv1beta1ctrl.ProxyConfig{
 			HTTPProxy:  httpProxy,
 			HTTPSProxy: httpsProxy,
@@ -741,7 +746,7 @@ func main() {
 		ControllerNamespace:   controllerNamespace,
 		NamespacePrefix:       namespacePrefix,
 		RandomNamespacePrefix: randomPrefix,
-		TaskSettings: lagoonv1beta1ctrl.LagoonTaskSettings{
+		LagoonAPIConfiguration: lagoonv1beta1ctrl.LagoonAPIConfiguration{
 			APIHost: lagoonAPIHost,
 			SSHHost: lagoonSSHHost,
 			SSHPort: lagoonSSHPort,


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

We currently inject `TASK_API_X` and `TASK_SSH_X` variables into tasks so that they can consume the API if required.

Builds should also have this injected, so that there is less reliance on having the `.lagoon.yml` file needing to be populated with the API/SSH endpoints (see https://docs.lagoon.sh/using-lagoon-the-basics/lagoon-yml/#api and https://docs.lagoon.sh/using-lagoon-the-basics/lagoon-yml/#ssh).

The new variables are as folllows, in addition to this, these are also now injected into tasks alongside the `TASK_` versions so that we can deprecate those in time.
* `LAGOON_CONFIG_API_HOST`
* `LAGOON_CONFIG_SSH_HOST`
* `LAGOON_CONFIG_SSH_PORT`

Will need to raise follow up issue in other repositories for things that consume the `.lagoon.yml` in remote systems to have them updated to consume the new variables. And also update the builds to be able to inject these into the `lagoon-env` configmap