### PR TITLE
use cluster names in robot account names

### DIFF
--- a/controller-test.sh
+++ b/controller-test.sh
@@ -251,7 +251,7 @@ echo '
                 \"statuspageID\": \"1234\"
             },
             \"variables\": {
-                \"project\": \"W10=\",
+                \"project\": \"W3sibmFtZSI6IkxBR09PTl9TWVNURU1fUk9VVEVSX1BBVFRFUk4iLCJ2YWx1ZSI6IiR7ZW52aXJvbm1lbnR9LiR7cHJvamVjdH0uZXhhbXBsZS5jb20iLCJzY29wZSI6ImludGVybmFsX3N5c3RlbSJ9XQ==\",
                 \"environment\": \"W10=\"
             },
             \"registry\": \"172.17.0.1:5000\"

--- a/internal/harbor/harborintegration.go
+++ b/internal/harbor/harborintegration.go
@@ -57,6 +57,7 @@ type Harbor struct {
 	RandomNamespacePrefix bool
 	WebhookURL            string
 	WebhookEventTypes     []string
+	LagoonTargetName      string
 	Config                *config.Options
 }
 
@@ -228,7 +229,7 @@ func (h *Harbor) matchRobotAccount(robotName string,
 	environmentName string,
 ) bool {
 	// pre global-robot-accounts (2.2.0+)
-	if robotName == h.addPrefix(environmentName) {
+	if robotName == h.addPrefix(fmt.Sprintf("%s-%s", environmentName, helpers.HashString(h.LagoonTargetName)[0:8])) {
 		return true
 	}
 	return false
@@ -239,7 +240,7 @@ func (h *Harbor) matchRobotAccountV2(robotName string,
 	projectName string,
 	environmentName string,
 ) bool {
-	if robotName == h.addPrefix(fmt.Sprintf("%s+%s", projectName, environmentName)) {
+	if robotName == h.addPrefixV2(projectName, environmentName) {
 		return true
 	}
 	return false

--- a/internal/harbor/harborintegration_test.go
+++ b/internal/harbor/harborintegration_test.go
@@ -1,0 +1,173 @@
+package harbor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	harborclientv3 "github.com/mittwald/goharbor-client/v3/apiv2"
+	harborclientv5 "github.com/mittwald/goharbor-client/v5/apiv2"
+	"github.com/mittwald/goharbor-client/v5/apiv2/pkg/config"
+)
+
+func TestHarbor_matchRobotAccount(t *testing.T) {
+	type fields struct {
+		URL                   string
+		Hostname              string
+		API                   string
+		Username              string
+		Password              string
+		Log                   logr.Logger
+		ClientV3              *harborclientv3.RESTClient
+		ClientV5              *harborclientv5.RESTClient
+		DeleteDisabled        bool
+		WebhookAddition       bool
+		RobotPrefix           string
+		ExpiryInterval        time.Duration
+		RotateInterval        time.Duration
+		RobotAccountExpiry    time.Duration
+		ControllerNamespace   string
+		NamespacePrefix       string
+		RandomNamespacePrefix bool
+		WebhookURL            string
+		WebhookEventTypes     []string
+		LagoonTargetName      string
+		Config                *config.Options
+	}
+	type args struct {
+		robotName       string
+		projectName     string
+		environmentName string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "test1",
+			fields: fields{
+				RobotPrefix:      "robot$",
+				LagoonTargetName: "ci-local-controller-kubernetes",
+			},
+			args: args{
+				robotName:       "robot$main-954f2d24",
+				projectName:     "example-com",
+				environmentName: "main",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Harbor{
+				URL:                   tt.fields.URL,
+				Hostname:              tt.fields.Hostname,
+				API:                   tt.fields.API,
+				Username:              tt.fields.Username,
+				Password:              tt.fields.Password,
+				Log:                   tt.fields.Log,
+				ClientV3:              tt.fields.ClientV3,
+				ClientV5:              tt.fields.ClientV5,
+				DeleteDisabled:        tt.fields.DeleteDisabled,
+				WebhookAddition:       tt.fields.WebhookAddition,
+				RobotPrefix:           tt.fields.RobotPrefix,
+				ExpiryInterval:        tt.fields.ExpiryInterval,
+				RotateInterval:        tt.fields.RotateInterval,
+				RobotAccountExpiry:    tt.fields.RobotAccountExpiry,
+				ControllerNamespace:   tt.fields.ControllerNamespace,
+				NamespacePrefix:       tt.fields.NamespacePrefix,
+				RandomNamespacePrefix: tt.fields.RandomNamespacePrefix,
+				WebhookURL:            tt.fields.WebhookURL,
+				WebhookEventTypes:     tt.fields.WebhookEventTypes,
+				LagoonTargetName:      tt.fields.LagoonTargetName,
+				Config:                tt.fields.Config,
+			}
+			if got := h.matchRobotAccount(tt.args.robotName, tt.args.projectName, tt.args.environmentName); got != tt.want {
+				t.Errorf("Harbor.matchRobotAccount() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHarbor_matchRobotAccountV2(t *testing.T) {
+	type fields struct {
+		URL                   string
+		Hostname              string
+		API                   string
+		Username              string
+		Password              string
+		Log                   logr.Logger
+		ClientV3              *harborclientv3.RESTClient
+		ClientV5              *harborclientv5.RESTClient
+		DeleteDisabled        bool
+		WebhookAddition       bool
+		RobotPrefix           string
+		ExpiryInterval        time.Duration
+		RotateInterval        time.Duration
+		RobotAccountExpiry    time.Duration
+		ControllerNamespace   string
+		NamespacePrefix       string
+		RandomNamespacePrefix bool
+		WebhookURL            string
+		WebhookEventTypes     []string
+		LagoonTargetName      string
+		Config                *config.Options
+	}
+	type args struct {
+		robotName       string
+		projectName     string
+		environmentName string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "test1",
+			fields: fields{
+				RobotPrefix:      "robot$",
+				LagoonTargetName: "ci-local-controller-kubernetes",
+			},
+			args: args{
+				robotName:       "robot$example-com+main-954f2d24",
+				projectName:     "example-com",
+				environmentName: "main",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &Harbor{
+				URL:                   tt.fields.URL,
+				Hostname:              tt.fields.Hostname,
+				API:                   tt.fields.API,
+				Username:              tt.fields.Username,
+				Password:              tt.fields.Password,
+				Log:                   tt.fields.Log,
+				ClientV3:              tt.fields.ClientV3,
+				ClientV5:              tt.fields.ClientV5,
+				DeleteDisabled:        tt.fields.DeleteDisabled,
+				WebhookAddition:       tt.fields.WebhookAddition,
+				RobotPrefix:           tt.fields.RobotPrefix,
+				ExpiryInterval:        tt.fields.ExpiryInterval,
+				RotateInterval:        tt.fields.RotateInterval,
+				RobotAccountExpiry:    tt.fields.RobotAccountExpiry,
+				ControllerNamespace:   tt.fields.ControllerNamespace,
+				NamespacePrefix:       tt.fields.NamespacePrefix,
+				RandomNamespacePrefix: tt.fields.RandomNamespacePrefix,
+				WebhookURL:            tt.fields.WebhookURL,
+				WebhookEventTypes:     tt.fields.WebhookEventTypes,
+				LagoonTargetName:      tt.fields.LagoonTargetName,
+				Config:                tt.fields.Config,
+			}
+			if got := h.matchRobotAccountV2(tt.args.robotName, tt.args.projectName, tt.args.environmentName); got != tt.want {
+				t.Errorf("Harbor.matchRobotAccountV2() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -570,6 +570,7 @@ func main() {
 		NamespacePrefix:       namespacePrefix,
 		RandomNamespacePrefix: randomPrefix,
 		WebhookURL:            harborLagoonWebhook,
+		LagoonTargetName:      lagoonTargetName,
 		WebhookEventTypes:     strings.Split(harborWebhookEventTypes, ","),
 	}
 

--- a/test-resources/example-project1.yaml
+++ b/test-resources/example-project1.yaml
@@ -24,7 +24,7 @@ spec:
             contact: '1234'
             statuspageID: '1234'
         variables:
-            project: W10=
+            project: W3sibmFtZSI6IkxBR09PTl9TWVNURU1fUk9VVEVSX1BBVFRFUk4iLCJ2YWx1ZSI6IiR7ZW52aXJvbm1lbnR9LiR7cHJvamVjdH0uZXhhbXBsZS5jb20iLCJzY29wZSI6ImludGVybmFsX3N5c3RlbSJ9XQ==
             environment: W10=
         registry: 172.17.0.1:5000
     branch:

--- a/test-resources/example-project2.yaml
+++ b/test-resources/example-project2.yaml
@@ -24,7 +24,7 @@ spec:
             contact: '1234'
             statuspageID: '1234'
         variables:
-            project: W10=
+            project: W3sibmFtZSI6IkxBR09PTl9TWVNURU1fUk9VVEVSX1BBVFRFUk4iLCJ2YWx1ZSI6IiR7ZW52aXJvbm1lbnR9LiR7cHJvamVjdH0uZXhhbXBsZS5jb20iLCJzY29wZSI6ImludGVybmFsX3N5c3RlbSJ9XQ==
             environment: W10=
         registry: 172.17.0.1:5000
     branch:


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Some cases it is useful to know which cluster generated the robot account. This is especially handy when doing migrations that share the same harbor.

This adds the cluster name to the robot account name.

Now robot accounts will be named like so, with a hashed version of the cluster name. A description is also added to the account to indicate which cluster it is in.
```
# harbor 2.1.x
robot$environment-abc123df
# harbor 2.2.x
robot$project+environment-abc123df
```