### PR TITLE
chore: change the default rotate interval to be 1d instead of 30d

### DIFF
--- a/main.go
+++ b/main.go
@@ -298,7 +298,7 @@ func main() {
 		"Tells harbor to delete any disabled robot accounts and re-create them if required.")
 	flag.StringVar(&harborExpiryInterval, "harbor-expiry-interval", "2d",
 		"The number of days or hours (eg 24h or 30d) before expiring credentials to re-fresh.")
-	flag.StringVar(&harborRotateInterval, "harbor-rotate-interval", "30d",
+	flag.StringVar(&harborRotateInterval, "harbor-rotate-interval", "1d",
 		"The number of days or hours (eg 24h or 30d) to force refresh if required.")
 	flag.StringVar(&harborRobotAccountExpiry, "harbor-robot-account-expiry", "30d",
 		"The number of days or hours (eg 24h or 30d) to set for new robot account expiration.")


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

There may be times where the 30d interval and the job to rotate credentials of 30d may not line up properly if running all the default interval configurations for credentials.

Changing the default interval to 1d will mean that credentials are rotated earlier to try reduce issues.
