### PR TITLE
feat: add support to delete any pods that might be remaining

### DIFF
--- a/controllers/messenger/queues.go
+++ b/controllers/messenger/queues.go
@@ -295,6 +295,10 @@ func (h *Messaging) Consumer(targetName string) { //error {
 						message.Ack(false) // ack to remove from queue
 						return
 					}
+					if del := h.DeletePods(ctx, opLog.WithName("DeletePods"), ns, project, branch); del == false {
+						message.Ack(false) // ack to remove from queue
+						return
+					}
 					if del := h.DeletePVCs(ctx, opLog.WithName("DeletePVCs"), ns, project, branch); del == false {
 						message.Ack(false) // ack to remove from queue
 						return


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

In some cases deleting jobs and deployments etc may still leave a pod lingering. This adds support to delete any remaining pods.
