### PR TITLE
feat: add support for lagoon-container-memory-limit flag

### DIFF
--- a/controllers/v1beta1/build_controller.go
+++ b/controllers/v1beta1/build_controller.go
@@ -75,6 +75,7 @@ type LagoonBuildReconciler struct {
 	LagoonFeatureFlags               map[string]string
 	LagoonAPIConfiguration           LagoonAPIConfiguration
 	ProxyConfig                      ProxyConfig
+	LagoonContainerMemoryLimit       string
 }
 
 // BackupConfig holds all the backup configuration settings

--- a/controllers/v1beta1/build_helpers.go
+++ b/controllers/v1beta1/build_helpers.go
@@ -531,6 +531,10 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 			Value: r.LagoonAPIConfiguration.SSHPort,
 		},
 		// in the future, the SSH_HOST and SSH_PORT could also have regional variants
+		{
+			Name:  "LAGOON_CONTAINER_MEMORY_LIMIT",
+			Value: r.LagoonContainerMemoryLimit,
+		},
 	}
 	// add proxy variables to builds if they are defined
 	if r.ProxyConfig.HTTPProxy != "" {

--- a/main.go
+++ b/main.go
@@ -157,6 +157,8 @@ func main() {
 	var enablePodProxy bool
 	var podsUseDifferentProxy bool
 
+	var lagoonContainerMemoryLimit string
+
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080",
 		"The address the metric endpoint binds to.")
 	flag.StringVar(&lagoonTargetName, "lagoon-target-name", "ci-local-control-k8s",
@@ -328,6 +330,9 @@ func main() {
 	// the number of attempts for cleaning up pvcs in a namespace default 30 attempts, 10 seconds apart (300 seconds total)
 	flag.IntVar(&pvcRetryAttempts, "delete-pvc-retry-attempts", 30, "How many attempts to check that PVCs have been removed (default 30).")
 	flag.IntVar(&pvcRetryInterval, "delete-pvc-retry-interval", 10, "The number of seconds between each retry attempt (default 10).")
+
+	flag.StringVar(&lagoonContainerMemoryLimit, "lagoon-container-memory-limit", "16Gi",
+		"Container memory limit for pods deployed by Lagoon")
 
 	flag.Parse()
 
@@ -732,6 +737,7 @@ func main() {
 			HTTPSProxy: httpsProxy,
 			NoProxy:    noProxy,
 		},
+		LagoonContainerMemoryLimit: lagoonContainerMemoryLimit,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LagoonBuild")
 		os.Exit(1)


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

This change is part of adding support for setting memory resource limits on containers deployed by Lagoon. The idea is that this is a limit which no container should ever reach. Hence the default value of `16Gi`, which is chosen as half the resources of a common node size today, of `32Gi`.

See https://github.com/uselagoon/build-deploy-tool/pull/120 for the associated build-deploy-tool PR.

# Closing issues

n/a