### PR TITLE
refactor: don't save build logs in resource

### DIFF
--- a/controllers/v1beta1/build_helpers.go
+++ b/controllers/v1beta1/build_helpers.go
@@ -41,29 +41,6 @@ This issue is related to the deployment system, not the repository or code base 
 Contact your Lagoon support team for help`
 )
 
-// updateBuildStatusCondition is used to patch the lagoon build with the status conditions for the build, plus any logs
-func (r *LagoonBuildReconciler) updateBuildStatusCondition(ctx context.Context,
-	lagoonBuild *lagoonv1beta1.LagoonBuild,
-	condition lagoonv1beta1.LagoonBuildConditions,
-	log []byte,
-) error {
-	// set the transition time
-	condition.LastTransitionTime = time.Now().UTC().Format(time.RFC3339)
-	if !helpers.BuildContainsStatus(lagoonBuild.Status.Conditions, condition) {
-		lagoonBuild.Status.Conditions = append(lagoonBuild.Status.Conditions, condition)
-		mergePatch, _ := json.Marshal(map[string]interface{}{
-			"status": map[string]interface{}{
-				"conditions": lagoonBuild.Status.Conditions,
-				"log":        log,
-			},
-		})
-		if err := r.Patch(ctx, lagoonBuild, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
-			return fmt.Errorf("Unable to update status condition: %v", err)
-		}
-	}
-	return nil
-}
-
 // getOrCreateServiceAccount will create the lagoon-deployer service account if it doesn't exist.
 func (r *LagoonBuildReconciler) getOrCreateServiceAccount(ctx context.Context, serviceAccount *corev1.ServiceAccount, ns string) error {
 	serviceAccount.ObjectMeta = metav1.ObjectMeta{

--- a/controllers/v1beta1/podmonitor_buildhandlers.go
+++ b/controllers/v1beta1/podmonitor_buildhandlers.go
@@ -486,7 +486,7 @@ Build %s
 			lagoonBuild.Status.Conditions = append(lagoonBuild.Status.Conditions, condition)
 			mergeMap["status"] = map[string]interface{}{
 				"conditions": lagoonBuild.Status.Conditions,
-				"log":        allContainerLogs,
+				// don't save build logs in resource anymore
 			}
 		}
 
@@ -523,7 +523,8 @@ Build %s
 			if pendingEnvironment {
 				mergeMap["statusMessages"].(map[string]interface{})["environmentMessage"] = pendingEnvironmentMessage
 			}
-			if pendingBuildLog {
+			// if the build log message is too long, don't save it
+			if pendingBuildLog && len(pendingBuildLogMessage.Message) > 1048576 {
 				mergeMap["statusMessages"].(map[string]interface{})["buildLogMessage"] = pendingBuildLogMessage
 			}
 		}

--- a/controllers/v1beta1/podmonitor_taskhandlers.go
+++ b/controllers/v1beta1/podmonitor_taskhandlers.go
@@ -340,7 +340,7 @@ Task %s
 			lagoonTask.Status.Conditions = append(lagoonTask.Status.Conditions, condition)
 			mergeMap["status"] = map[string]interface{}{
 				"conditions": lagoonTask.Status.Conditions,
-				"log":        allContainerLogs,
+				// don't save build logs in resource anymore
 			}
 		}
 


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

As #173 explains, if a build log exceeds the size of what can be stored in a resource, it can fail to update the lagoon API and cause build processing to stall. 

This PR disables patching the resource with the build log to prevent this issue from occurring. There is an existing `pending` place holder that can also store this, which has a hard limit of 1MB of build logs, but this is only ever used if the queue goes down. Eventually I think this functionality can also be removed.

# Closing issues

closes #173 