### PR TITLE
Feature: Terminate long running builds and tasks

### DIFF
--- a/controllers/v1beta1/podmonitor_buildhandlers.go
+++ b/controllers/v1beta1/podmonitor_buildhandlers.go
@@ -452,10 +452,14 @@ func (r *LagoonMonitorReconciler) updateDeploymentWithLogs(
 				allContainerLogs, err = r.collectLogs(ctx, req, jobPod)
 				if err == nil {
 					if cancel {
+						cancellationMessage := "Build cancelled"
+						if cancellationDetails, ok := jobPod.GetAnnotations()["lagoon.sh/cancelReason"]; ok {
+							cancellationMessage = fmt.Sprintf("%v : %v", cancellationMessage, cancellationDetails)
+						}
 						allContainerLogs = append(allContainerLogs, []byte(fmt.Sprintf(`
 ========================================
-Build cancelled
-========================================`))...)
+%v
+========================================`, cancellationMessage))...)
 					}
 				} else {
 					allContainerLogs = []byte(fmt.Sprintf(`

--- a/controllers/v1beta1/podmonitor_taskhandlers.go
+++ b/controllers/v1beta1/podmonitor_taskhandlers.go
@@ -307,10 +307,14 @@ func (r *LagoonMonitorReconciler) updateTaskWithLogs(
 				allContainerLogs, err = r.collectLogs(ctx, req, jobPod)
 				if err == nil {
 					if cancel {
+						cancellationMessage := "Task cancelled"
+						if cancellationDetails, ok := jobPod.GetAnnotations()["lagoon.sh/cancelReason"]; ok {
+							cancellationMessage = fmt.Sprintf("%v : %v", cancellationMessage, cancellationDetails)
+						}
 						allContainerLogs = append(allContainerLogs, []byte(fmt.Sprintf(`
 ========================================
-Task cancelled
-========================================`))...)
+%v
+========================================`, cancellationMessage))...)
 					}
 				} else {
 					allContainerLogs = []byte(fmt.Sprintf(`

--- a/internal/utilities/pruner/old_process_pruner.go
+++ b/internal/utilities/pruner/old_process_pruner.go
@@ -19,7 +19,6 @@ import (
 // LagoonOldProcPruner will identify and remove any long running builds or tasks.
 func (p *Pruner) LagoonOldProcPruner(pruneBuilds, pruneTasks bool) {
 	opLog := ctrl.Log.WithName("utilities").WithName("LagoonOldProcPruner")
-	opLog.Info("Beginning marking old build and task pods")
 	namespaces := &corev1.NamespaceList{}
 	labelRequirements, _ := labels.NewRequirement("lagoon.sh/environmentType", selection.Exists, nil)
 	listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
@@ -37,7 +36,6 @@ func (p *Pruner) LagoonOldProcPruner(pruneBuilds, pruneTasks bool) {
 
 		if ns.Status.Phase == corev1.NamespaceTerminating {
 			// if the namespace is terminating, don't search it for long running tasks
-			opLog.Info(fmt.Sprintf("Namespace %s is being terminated, skipping build/task pruner", ns.ObjectMeta.Name))
 			continue
 		}
 

--- a/internal/utilities/pruner/old_process_pruner.go
+++ b/internal/utilities/pruner/old_process_pruner.go
@@ -1,0 +1,115 @@
+package pruner
+
+import (
+	"context"
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+	//lagoonv1beta1 "github.com/uselagoon/remote-controller/apis/lagoon/v1beta1"
+	//"github.com/uselagoon/remote-controller/internal/helpers"
+)
+
+// LagoonOldProcPruner will identify and remove any long running builds or tasks.
+func (p *Pruner) LagoonOldProcPruner() {
+	opLog := ctrl.Log.WithName("utilities").WithName("LagoonOldProcPruner")
+	opLog.Info("Beginning marking old build and task pods")
+	namespaces := &corev1.NamespaceList{}
+	labelRequirements, _ := labels.NewRequirement("lagoon.sh/environmentType", selection.Exists, nil)
+	listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
+		client.MatchingLabelsSelector{
+			Selector: labels.NewSelector().Add(*labelRequirements),
+		},
+	})
+	if err := p.Client.List(context.Background(), namespaces, listOption); err != nil {
+		opLog.Error(err, fmt.Sprintf("Unable to list namespaces created by Lagoon, there may be none or something went wrong"))
+		return
+	}
+
+	//now we iterate through each namespace, and look for build/task pods
+	for _, ns := range namespaces.Items {
+		if ns.Status.Phase == corev1.NamespaceTerminating {
+			// if the namespace is terminating, don't search it for long running tasks
+			opLog.Info(fmt.Sprintf("Namespace %s is being terminated, skipping build/task pruner", ns.ObjectMeta.Name))
+			continue
+		}
+
+		//Now let's look for build and task pods
+		// NOTE: build and task pods really are the same kind of thing, right - they're simply pods, but tagged differently
+		// So what we're going to do is just find those that match the various
+
+		podList := corev1.PodList{
+			TypeMeta: metav1.TypeMeta{},
+			ListMeta: metav1.ListMeta{},
+			Items:    nil,
+		}
+
+		listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
+			client.InNamespace(ns.ObjectMeta.Name),
+			client.MatchingLabels(map[string]string{
+				"lagoon.sh/controller": p.ControllerNamespace, // created by this controller
+			}),
+		})
+		if err := p.Client.List(context.Background(), &podList, listOption); err != nil {
+			opLog.Error(err, fmt.Sprintf("Unable to list pod resources, there may be none or something went wrong"))
+			continue
+		}
+
+		opLog.Info(fmt.Sprintf("Running task/build recon"))
+
+		hours, err := time.ParseDuration(fmt.Sprintf("%vh", p.TimeoutForWorkerPods))
+		if err != nil {
+			opLog.Error(err,
+				fmt.Sprintf(
+					"Unable to parse TimeoutForWorkerPods '%v' - cannot run long running task removal process.",
+					p.TimeoutForWorkerPods,
+				),
+			)
+			return
+		}
+		removeIfCreatedBefore := time.Now().Add(-time.Hour * hours)
+
+		for _, pod := range podList.Items {
+			if pod.Status.Phase == corev1.PodRunning {
+				opLog.Info(fmt.Sprintf("Found a pod named - %v", pod.Name))
+
+				if pod.CreationTimestamp.Time.Before(removeIfCreatedBefore) || true {
+					if podType, ok := pod.GetLabels()["lagoon.sh/jobType"]; ok {
+						switch podType {
+						case "task":
+							//podTypeName = "task"
+							pod.ObjectMeta.Labels["lagoon.sh/cancelTask"] = "true"
+							pod.ObjectMeta.Annotations["lagoon.sh/cancelReason"] = fmt.Sprintf("Cancelled task due to timeout")
+							break
+						case "build":
+							//podTypeName = "build"
+							pod.ObjectMeta.Labels["lagoon.sh/cancelBuild"] = "true"
+							pod.ObjectMeta.Annotations["lagoon.sh/cancelReason"] = fmt.Sprintf("Cancelled build due to timeout")
+							break
+						default:
+							return
+						}
+						// this isn't actually a job, so we skip
+						if err := p.Client.Update(context.Background(), &pod); err != nil {
+							opLog.Error(err,
+								fmt.Sprintf(
+									"Unable to update %s to cancel it.",
+									pod.Name,
+								),
+							)
+						}
+						opLog.Info("Cancelled pod %v - timeout", pod.Name)
+					} else {
+						continue
+					}
+
+				}
+			}
+		}
+		opLog.Info(fmt.Sprintf("Endint task/build recon"))
+	}
+}

--- a/internal/utilities/pruner/old_process_pruner_test.go
+++ b/internal/utilities/pruner/old_process_pruner_test.go
@@ -1,0 +1,101 @@
+package pruner
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func Test_calculateRemoveBeforeTimes(t *testing.T) {
+	type args struct {
+		p         *Pruner
+		ns        v1.Namespace
+		startTime time.Time
+	}
+	tests := []struct {
+		name            string
+		args            args
+		buildBeforeTime time.Time
+		taskBeforeTime  time.Time
+		wantErr         bool
+	}{
+		{
+			name: "Kill immediately (empty test)",
+			args: args{
+				p: &Pruner{
+					TimeoutForBuildPods: 0,
+					TimeoutForTaskPods:  0,
+				},
+				ns: v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							//"lagoon.sh/buildPodTimeout": "1"
+						},
+						//Annotations: nil,
+					},
+				},
+				startTime: time.Date(2000, 1, 1, 1, 1, 1, 1, time.Local),
+			},
+			buildBeforeTime: time.Date(2000, 1, 1, 1, 1, 1, 1, time.Local),
+			taskBeforeTime:  time.Date(2000, 1, 1, 1, 1, 1, 1, time.Local),
+		},
+		{
+			name: "Kill 6 hours earlier - given by pruner settings",
+			args: args{
+				p: &Pruner{
+					TimeoutForBuildPods: 6,
+					TimeoutForTaskPods:  6,
+				},
+				ns: v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							//"lagoon.sh/buildPodTimeout": "1"
+						},
+						//Annotations: nil,
+					},
+				},
+				startTime: time.Date(2000, 1, 1, 7, 1, 1, 1, time.Local),
+			},
+			buildBeforeTime: time.Date(2000, 1, 1, 1, 1, 1, 1, time.Local),
+			taskBeforeTime:  time.Date(2000, 1, 1, 1, 1, 1, 1, time.Local),
+		},
+		{
+			name: "Kill 1 hours earlier - given by ns override",
+			args: args{
+				p: &Pruner{
+					TimeoutForBuildPods: 6,
+					TimeoutForTaskPods:  6,
+				},
+				ns: v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"lagoon.sh/buildPodTimeout": "2",
+							"lagoon.sh/taskPodTimeout":  "1",
+						},
+						//Annotations: nil,
+					},
+				},
+				startTime: time.Date(2000, 1, 1, 3, 1, 1, 1, time.Local),
+			},
+			buildBeforeTime: time.Date(2000, 1, 1, 1, 1, 1, 1, time.Local),
+			taskBeforeTime:  time.Date(2000, 1, 1, 2, 1, 1, 1, time.Local),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := calculateRemoveBeforeTimes(tt.args.p, tt.args.ns, tt.args.startTime)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("calculateRemoveBeforeTimes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.buildBeforeTime) {
+				t.Errorf("calculateRemoveBeforeTimes() got = %v, buildBeforeTime %v", got, tt.buildBeforeTime)
+			}
+			if !reflect.DeepEqual(got1, tt.taskBeforeTime) {
+				t.Errorf("calculateRemoveBeforeTimes() got1 = %v, buildBeforeTime %v", got1, tt.taskBeforeTime)
+			}
+		})
+	}
+}

--- a/internal/utilities/pruner/pruner.go
+++ b/internal/utilities/pruner/pruner.go
@@ -22,6 +22,7 @@ type Pruner struct {
 	NamespacePrefix       string
 	RandomNamespacePrefix bool
 	DeletionHandler       *deletions.Deletions
+	TimeoutForWorkerPods  int
 	EnableDebug           bool
 }
 
@@ -34,15 +35,17 @@ func New(
 	taskPodsToKeep int,
 	controllerNamespace string,
 	deletionHandler *deletions.Deletions,
+	timeoutForWorkerPods int,
 	enableDebug bool) *Pruner {
 	return &Pruner{
-		Client:              client,
-		BuildsToKeep:        buildsToKeep,
-		TasksToKeep:         tasksToKeep,
-		BuildPodsToKeep:     buildPodsToKeep,
-		TaskPodsToKeep:      taskPodsToKeep,
-		ControllerNamespace: controllerNamespace,
-		DeletionHandler:     deletionHandler,
-		EnableDebug:         enableDebug,
+		Client:               client,
+		BuildsToKeep:         buildsToKeep,
+		TasksToKeep:          tasksToKeep,
+		BuildPodsToKeep:      buildPodsToKeep,
+		TaskPodsToKeep:       taskPodsToKeep,
+		ControllerNamespace:  controllerNamespace,
+		DeletionHandler:      deletionHandler,
+		TimeoutForWorkerPods: timeoutForWorkerPods,
+		EnableDebug:          enableDebug,
 	}
 }

--- a/internal/utilities/pruner/pruner.go
+++ b/internal/utilities/pruner/pruner.go
@@ -22,7 +22,8 @@ type Pruner struct {
 	NamespacePrefix       string
 	RandomNamespacePrefix bool
 	DeletionHandler       *deletions.Deletions
-	TimeoutForWorkerPods  int
+	TimeoutForBuildPods   int
+	TimeoutForTaskPods    int
 	EnableDebug           bool
 }
 
@@ -35,17 +36,19 @@ func New(
 	taskPodsToKeep int,
 	controllerNamespace string,
 	deletionHandler *deletions.Deletions,
-	timeoutForWorkerPods int,
+	timeoutForBuildPods int,
+	timeoutForTaskPods int,
 	enableDebug bool) *Pruner {
 	return &Pruner{
-		Client:               client,
-		BuildsToKeep:         buildsToKeep,
-		TasksToKeep:          tasksToKeep,
-		BuildPodsToKeep:      buildPodsToKeep,
-		TaskPodsToKeep:       taskPodsToKeep,
-		ControllerNamespace:  controllerNamespace,
-		DeletionHandler:      deletionHandler,
-		TimeoutForWorkerPods: timeoutForWorkerPods,
-		EnableDebug:          enableDebug,
+		Client:              client,
+		BuildsToKeep:        buildsToKeep,
+		TasksToKeep:         tasksToKeep,
+		BuildPodsToKeep:     buildPodsToKeep,
+		TaskPodsToKeep:      taskPodsToKeep,
+		ControllerNamespace: controllerNamespace,
+		DeletionHandler:     deletionHandler,
+		TimeoutForBuildPods: timeoutForBuildPods,
+		TimeoutForTaskPods:  timeoutForTaskPods,
+		EnableDebug:         enableDebug,
 	}
 }


### PR DESCRIPTION
This introduces functionality to delete long running tasks and builds, the default termination value is 6 hours. This is adjustable via flags. It is enabled by default.

There is the ability to label namespaces with additional labels that can override the default, eventually these will be configurable in the Lagoon API though.

# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

# Closing issues

closes #182 