### PR TITLE
fix: ensure statusmessages field exists

### DIFF
--- a/controllers/v1beta1/podmonitor_buildhandlers.go
+++ b/controllers/v1beta1/podmonitor_buildhandlers.go
@@ -479,6 +479,7 @@ Build %s
 					"lagoon.sh/buildStarted": "true",
 				},
 			},
+			"statusMessages": map[string]interface{}{},
 		}
 
 		condition := lagoonv1beta1.LagoonBuildConditions{

--- a/controllers/v1beta1/podmonitor_taskhandlers.go
+++ b/controllers/v1beta1/podmonitor_taskhandlers.go
@@ -333,6 +333,7 @@ Task %s
 					"lagoon.sh/taskStatus": string(taskCondition),
 				},
 			},
+			"statusMessages": map[string]interface{}{},
 		}
 
 		condition := lagoonv1beta1.LagoonTaskConditions{


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

When trying to save the status message/log information of a build or task, the merge data that would be saved in the CRD was missing a field definition.

This adds that missing field
