### PR TITLE
Feature: add lagoon-env configmap to advanced task spec

### DIFF
--- a/controllers/v1beta1/build_controller.go
+++ b/controllers/v1beta1/build_controller.go
@@ -239,6 +239,16 @@ func (r *LagoonBuildReconciler) createNamespaceBuild(ctx context.Context,
 		return ctrl.Result{}, err
 	}
 
+	// Get or create the lagoon-env configmap
+	lagoonEnvConfigMap := &corev1.ConfigMap{}
+	if r.EnableDebug {
+		opLog.Info("Checking `lagoon-env` configMap exists - creating if not")
+	}
+	err = r.getOrCreateConfigMap(ctx, "lagoon-env", lagoonEnvConfigMap, namespace.ObjectMeta.Name)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// copy the build resource into a new resource and set the status to pending
 	// create the new resource and the controller will handle it via queue
 	opLog.Info(fmt.Sprintf("Creating LagoonBuild in Pending status: %s", lagoonBuild.ObjectMeta.Name))

--- a/controllers/v1beta1/build_helpers.go
+++ b/controllers/v1beta1/build_helpers.go
@@ -287,6 +287,22 @@ func (r *LagoonBuildReconciler) getCreateOrUpdateSSHKeySecret(ctx context.Contex
 	return nil
 }
 
+func (r *LagoonBuildReconciler) getOrCreateConfigMap(ctx context.Context, cmName string, configMap *corev1.ConfigMap, ns string) error {
+	err := r.Get(ctx, types.NamespacedName{
+		Namespace: ns,
+		Name:      cmName,
+	}, configMap)
+	if err != nil {
+		configMap.SetNamespace(ns)
+		configMap.SetName(cmName)
+		//we create it
+		if err = r.Create(ctx, configMap); err != nil {
+			return fmt.Errorf("There was an error creating the configmap '%v'. Error was: %v", cmName, err)
+		}
+	}
+	return nil
+}
+
 // getOrCreatePromoteSARoleBinding will create the rolebinding for openshift promotions to be used by the lagoon-deployer service account.
 // @TODO: this role binding can be used as a basis for active/standby tasks allowing one ns to work in another ns
 func (r *LagoonBuildReconciler) getOrCreatePromoteSARoleBinding(ctx context.Context, sourcens string, ns string) error {

--- a/controllers/v1beta1/task_controller.go
+++ b/controllers/v1beta1/task_controller.go
@@ -435,6 +435,15 @@ func (r *LagoonTaskReconciler) createAdvancedTask(ctx context.Context, lagoonTas
 					Name:            "lagoon-task",
 					Image:           lagoonTask.Spec.AdvancedTask.RunnerImage,
 					ImagePullPolicy: "Always",
+					EnvFrom: []corev1.EnvFromSource{
+						{
+							ConfigMapRef: &corev1.ConfigMapEnvSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "lagoon-env",
+								},
+							},
+						},
+					},
 					Env: []corev1.EnvVar{
 						{
 							Name:  "JSON_PAYLOAD",


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Currently, advanced tasks don't mount the "lagoon-env" configmap, and so some variables that should legitimately be available to the task aren't. This PR adds it.
