### PR TITLE
refactor: support for legacy and bound serviceaccount tokens

### DIFF
--- a/.github/workflows/remote-controller.yaml
+++ b/.github/workflows/remote-controller.yaml
@@ -18,16 +18,16 @@ jobs:
       matrix:
         kindest_node_version: [v1.21.12, v1.22.9]
         harbor: ["1.5.6", "1.9.0"]
-        lagoon_build_image: ["uselagoon/build-deploy-image:latest"]
+        lagoon_build_image: ["uselagoon/build-deploy-image:main"]
         experimental: [false]
         include:
           - kindest_node_version: v1.23.6
             harbor: "1.9.0"
-            lagoon_build_image: "uselagoon/build-deploy-image:latest"
+            lagoon_build_image: "uselagoon/build-deploy-image:main"
             experimental: true
           - kindest_node_version: v1.24.7
             harbor: "1.9.0"
-            lagoon_build_image: "uselagoon/build-deploy-image:latest"
+            lagoon_build_image: "uselagoon/build-deploy-image:main"
             experimental: true
     steps:
     - name: Checkout

--- a/.github/workflows/remote-controller.yaml
+++ b/.github/workflows/remote-controller.yaml
@@ -25,6 +25,10 @@ jobs:
             harbor: "1.9.0"
             lagoon_build_image: "uselagoon/build-deploy-image:latest"
             experimental: true
+          - kindest_node_version: v1.24.7
+            harbor: "1.9.0"
+            lagoon_build_image: "uselagoon/build-deploy-image:latest"
+            experimental: true
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/controllers/v1beta1/build_helpers.go
+++ b/controllers/v1beta1/build_helpers.go
@@ -424,6 +424,7 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 	if r.EnableDebug {
 		opLog.Info(fmt.Sprintf("Checking `lagoon-deployer` Token exists: %s", lagoonBuild.ObjectMeta.Name))
 	}
+
 	var serviceaccountTokenSecret string
 	for _, secret := range serviceAccount.Secrets {
 		match, _ := regexp.MatchString("^lagoon-deployer-token", secret.Name)
@@ -431,9 +432,6 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 			serviceaccountTokenSecret = secret.Name
 			break
 		}
-	}
-	if serviceaccountTokenSecret == "" {
-		return fmt.Errorf("Could not find token secret for ServiceAccount lagoon-deployer")
 	}
 
 	// create the Pod that will do the work
@@ -804,6 +802,44 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 		// otherwise if the build spec contains an image definition, use it instead.
 		buildImage = lagoonBuild.Spec.Build.Image
 	}
+	volumes := []corev1.Volume{
+		{
+			Name: "lagoon-sshkey",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  "lagoon-sshkey",
+					DefaultMode: helpers.IntPtr(420),
+				},
+			},
+		},
+	}
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      "lagoon-sshkey",
+			ReadOnly:  true,
+			MountPath: "/var/run/secrets/lagoon/ssh",
+		},
+	}
+
+	// if the existing token exists, mount it
+	if serviceaccountTokenSecret != "" {
+		volumes = append(volumes, corev1.Volume{
+			Name: serviceaccountTokenSecret,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  serviceaccountTokenSecret,
+					DefaultMode: helpers.IntPtr(420),
+				},
+			},
+		})
+		// legacy tokens are mounted /var/run/secrets/lagoon/deployer
+		// new tokens using volume projection are mounted /var/run/secrets/kubernetes.io/serviceaccount/token
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      serviceaccountTokenSecret,
+			ReadOnly:  true,
+			MountPath: "/var/run/secrets/lagoon/deployer",
+		})
+	}
 	newPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      lagoonBuild.ObjectMeta.Name,
@@ -825,27 +861,9 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 			},
 		},
 		Spec: corev1.PodSpec{
-			RestartPolicy: "Never",
-			Volumes: []corev1.Volume{
-				{
-					Name: serviceaccountTokenSecret,
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName:  serviceaccountTokenSecret,
-							DefaultMode: helpers.IntPtr(420),
-						},
-					},
-				},
-				{
-					Name: "lagoon-sshkey",
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName:  "lagoon-sshkey",
-							DefaultMode: helpers.IntPtr(420),
-						},
-					},
-				},
-			},
+			ServiceAccountName: "lagoon-deployer",
+			RestartPolicy:      "Never",
+			Volumes:            volumes,
 			Tolerations: []corev1.Toleration{
 				{
 					Key:      "lagoon/build",
@@ -874,18 +892,7 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 					Image:           buildImage,
 					ImagePullPolicy: "Always",
 					Env:             podEnvs,
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      serviceaccountTokenSecret,
-							ReadOnly:  true,
-							MountPath: "/var/run/secrets/lagoon/deployer",
-						},
-						{
-							Name:      "lagoon-sshkey",
-							ReadOnly:  true,
-							MountPath: "/var/run/secrets/lagoon/ssh",
-						},
-					},
+					VolumeMounts:    volumeMounts,
 				},
 			},
 		},


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

The `lagoon-deployer` service account token is not created in kubernetes 1.24 via `kind: Secret` anymore. Kubernetes has supported bound tokens for a few versions now.

This PR supports mounting the legacy token if it exists (for clusters and environments created prior to kubernetes 1.24), but will still provide the bound token via projected volume mounts by running the pod with the `lagoon-deployer` service account.

The following PRs address changing the location for the bound token, but still allowing for legacy to be used.
* https://github.com/uselagoon/build-deploy-tool/pull/140
* https://github.com/uselagoon/lagoon/pull/3325

These will have to exist for some time for transitioning

# Closing issues

closes #151 