### PR TITLE
chore: change the controller to use the latest build-deploy-image

### DIFF
--- a/main.go
+++ b/main.go
@@ -194,7 +194,7 @@ func main() {
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableMQ, "enable-message-queue", true,
 		"Enable message queue to provide updates back to Lagoon.")
-	flag.StringVar(&overrideBuildDeployImage, "override-builddeploy-image", "uselagoon/kubectl-build-deploy-dind:latest",
+	flag.StringVar(&overrideBuildDeployImage, "override-builddeploy-image", "uselagoon/build-deploy-image:latest",
 		"The build and deploy image that should be used by builds started by the controller.")
 	flag.StringVar(&namespacePrefix, "namespace-prefix", "",
 		"The prefix that will be added to all namespaces that are generated, maximum 8 characters. (only used if random-prefix is set false)")


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

kubectl-build-deploy-dind image has not been used for some time. This updates the default image to be the latest build-deploy-image instead.