### PR TITLE
fix: use the right no proxy variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -431,11 +431,11 @@ func main() {
 	if enablePodProxy {
 		httpProxy = helpers.GetEnv("HTTP_PROXY", httpProxy)
 		httpsProxy = helpers.GetEnv("HTTPS_PROXY", httpsProxy)
-		noProxy = helpers.GetEnv("HTTP_PROXY", noProxy)
+		noProxy = helpers.GetEnv("NO_PROXY", noProxy)
 		if podsUseDifferentProxy {
 			httpProxy = helpers.GetEnv("LAGOON_HTTP_PROXY", httpProxy)
 			httpsProxy = helpers.GetEnv("LAGOON_HTTPS_PROXY", httpsProxy)
-			noProxy = helpers.GetEnv("LAGOON_HTTP_PROXY", noProxy)
+			noProxy = helpers.GetEnv("LAGOON_NO_PROXY", noProxy)
 		}
 	}
 


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

If utilising the proxy configuration in the controller, if using `no_proxy`, the actual inserted value is of the `http_proxy`, this fixes it so that the right `no_proxy` value is used.
