### PR TITLE
feat: add log for queue position to queued builds

### DIFF
--- a/apis/lagoon/v1beta1/lagoonbuild_types.go
+++ b/apis/lagoon/v1beta1/lagoonbuild_types.go
@@ -16,6 +16,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -25,8 +27,10 @@ type BuildStatusType string
 
 // These are valid conditions of a job.
 const (
-	// BuildStatusRunning means the build is pending.
+	// BuildStatusPending means the build is pending.
 	BuildStatusPending BuildStatusType = "Pending"
+	// BuildStatusQueued means the build is queued.
+	BuildStatusQueued BuildStatusType = "Queued"
 	// BuildStatusRunning means the build is running.
 	BuildStatusRunning BuildStatusType = "Running"
 	// BuildStatusComplete means the build has completed its execution.
@@ -36,6 +40,14 @@ const (
 	// BuildStatusCancelled means the job been cancelled.
 	BuildStatusCancelled BuildStatusType = "Cancelled"
 )
+
+func (b BuildStatusType) String() string {
+	return string(b)
+}
+
+func (b BuildStatusType) ToLower() string {
+	return strings.ToLower(b.String())
+}
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.

--- a/apis/lagoon/v1beta1/lagoontask_types.go
+++ b/apis/lagoon/v1beta1/lagoontask_types.go
@@ -16,6 +16,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -28,11 +30,13 @@ type TaskStatusType string
 
 // These are valid conditions of a job.
 const (
-	// TaskStatusRunning means the build is pending.
+	// TaskStatusPending means the job is pending.
 	TaskStatusPending TaskStatusType = "Pending"
-	// TaskStatusRunning means the build is running.
+	// TaskStatusQueued means the job is queued.
+	TaskStatusQueued TaskStatusType = "Queued"
+	// TaskStatusRunning means the job is running.
 	TaskStatusRunning TaskStatusType = "Running"
-	// TaskStatusComplete means the build has completed its execution.
+	// TaskStatusComplete means the job has completed its execution.
 	TaskStatusComplete TaskStatusType = "Complete"
 	// TaskStatusFailed means the job has failed its execution.
 	TaskStatusFailed TaskStatusType = "Failed"
@@ -40,16 +44,28 @@ const (
 	TaskStatusCancelled TaskStatusType = "Cancelled"
 )
 
+func (b TaskStatusType) String() string {
+	return string(b)
+}
+
+func (b TaskStatusType) ToLower() string {
+	return strings.ToLower(b.String())
+}
+
 // TaskType const for the status type
 type TaskType string
 
 // These are valid conditions of a job.
 const (
-	// TaskStatusRunning means the build is pending.
+	// TaskTypeStandard means the task is a standard task.
 	TaskTypeStandard TaskType = "standard"
-	// TaskStatusRunning means the build is running.
+	// TaskTypeAdvanced means the task is an advanced task.
 	TaskTypeAdvanced TaskType = "advanced"
 )
+
+func (b TaskType) String() string {
+	return string(b)
+}
 
 // LagoonTaskSpec defines the desired state of LagoonTask
 type LagoonTaskSpec struct {

--- a/controllers/v1beta1/build_controller.go
+++ b/controllers/v1beta1/build_controller.go
@@ -123,7 +123,7 @@ func (r *LagoonBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// if the build isn't being deleted, but the status is cancelled
 		// then clean up the undeployable build
 		if value, ok := lagoonBuild.ObjectMeta.Labels["lagoon.sh/buildStatus"]; ok {
-			if value == string(lagoonv1beta1.BuildStatusCancelled) {
+			if value == lagoonv1beta1.BuildStatusCancelled.String() {
 				if value, ok := lagoonBuild.ObjectMeta.Labels["lagoon.sh/cancelledByNewBuild"]; ok {
 					if value == "true" {
 						opLog.Info(fmt.Sprintf("Cleaning up build %s as cancelled by new build", lagoonBuild.ObjectMeta.Name))
@@ -142,7 +142,7 @@ func (r *LagoonBuildReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
 				client.InNamespace(req.Namespace),
 				client.MatchingLabels(map[string]string{
-					"lagoon.sh/buildStatus": string(lagoonv1beta1.BuildStatusRunning),
+					"lagoon.sh/buildStatus": lagoonv1beta1.BuildStatusRunning.String(),
 					"lagoon.sh/controller":  r.ControllerNamespace,
 				}),
 			})
@@ -261,7 +261,7 @@ func (r *LagoonBuildReconciler) createNamespaceBuild(ctx context.Context,
 	// the `lagoon.sh/buildStatus = Pending` now
 	// so end this reconcile process
 	pendingBuilds := &lagoonv1beta1.LagoonBuildList{}
-	return ctrl.Result{}, helpers.CancelExtraBuilds(ctx, r.Client, opLog, pendingBuilds, namespace.ObjectMeta.Name, string(lagoonv1beta1.BuildStatusPending))
+	return ctrl.Result{}, helpers.CancelExtraBuilds(ctx, r.Client, opLog, pendingBuilds, namespace.ObjectMeta.Name, lagoonv1beta1.BuildStatusPending.String())
 }
 
 // getOrCreateBuildResource will deepcopy the lagoon build into a new resource and push it to the new namespace
@@ -272,7 +272,7 @@ func (r *LagoonBuildReconciler) getOrCreateBuildResource(ctx context.Context, bu
 	newBuild.SetResourceVersion("")
 	newBuild.SetLabels(
 		map[string]string{
-			"lagoon.sh/buildStatus": string(lagoonv1beta1.BuildStatusPending),
+			"lagoon.sh/buildStatus": lagoonv1beta1.BuildStatusPending.String(),
 			"lagoon.sh/controller":  r.ControllerNamespace,
 		},
 	)

--- a/controllers/v1beta1/build_deletionhandlers.go
+++ b/controllers/v1beta1/build_deletionhandlers.go
@@ -87,7 +87,7 @@ func (r *LagoonBuildReconciler) deleteExternalResources(
 	listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
 		client.InNamespace(lagoonBuild.ObjectMeta.Namespace),
 		client.MatchingLabels(map[string]string{
-			"lagoon.sh/buildStatus": string(lagoonv1beta1.BuildStatusRunning),
+			"lagoon.sh/buildStatus": lagoonv1beta1.BuildStatusRunning.String(),
 			"lagoon.sh/controller":  r.ControllerNamespace,
 		}),
 	})
@@ -111,7 +111,7 @@ func (r *LagoonBuildReconciler) deleteExternalResources(
 		listOption = (&client.ListOptions{}).ApplyOptions([]client.ListOption{
 			client.InNamespace(lagoonBuild.ObjectMeta.Namespace),
 			client.MatchingLabels(map[string]string{
-				"lagoon.sh/buildStatus": string(lagoonv1beta1.BuildStatusPending),
+				"lagoon.sh/buildStatus": lagoonv1beta1.BuildStatusPending.String(),
 				"lagoon.sh/controller":  r.ControllerNamespace,
 			}),
 		})
@@ -138,7 +138,7 @@ func (r *LagoonBuildReconciler) deleteExternalResources(
 			mergePatch, _ := json.Marshal(map[string]interface{}{
 				"metadata": map[string]interface{}{
 					"labels": map[string]interface{}{
-						"lagoon.sh/buildStatus": string(lagoonv1beta1.BuildStatusRunning),
+						"lagoon.sh/buildStatus": lagoonv1beta1.BuildStatusRunning.String(),
 					},
 				},
 			})
@@ -185,11 +185,11 @@ Build cancelled
 ========================================`))
 		var buildCondition lagoonv1beta1.BuildStatusType
 		buildCondition = lagoonv1beta1.BuildStatusCancelled
-		lagoonBuild.Labels["lagoon.sh/buildStatus"] = string(buildCondition)
+		lagoonBuild.Labels["lagoon.sh/buildStatus"] = buildCondition.String()
 		mergePatch, _ := json.Marshal(map[string]interface{}{
 			"metadata": map[string]interface{}{
 				"labels": map[string]interface{}{
-					"lagoon.sh/buildStatus": string(buildCondition),
+					"lagoon.sh/buildStatus": buildCondition.String(),
 				},
 			},
 		})
@@ -212,10 +212,10 @@ Build cancelled
 			}
 		}
 		// send any messages to lagoon message queues
-		// update the deployment with the status
-		r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &lagoonEnv, true)
-		r.updateDeploymentAndEnvironmentTask(ctx, opLog, &lagoonBuild, &lagoonEnv, true)
-		r.buildLogsToLagoonLogs(ctx, opLog, &lagoonBuild, allContainerLogs, true)
+		// update the deployment with the status of cancelled in lagoon
+		r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &lagoonEnv, lagoonv1beta1.BuildStatusCancelled)
+		r.updateDeploymentAndEnvironmentTask(ctx, opLog, &lagoonBuild, &lagoonEnv, lagoonv1beta1.BuildStatusCancelled)
+		r.buildLogsToLagoonLogs(ctx, opLog, &lagoonBuild, allContainerLogs, lagoonv1beta1.BuildStatusCancelled)
 	}
 	return nil
 }
@@ -226,14 +226,12 @@ func (r *LagoonBuildReconciler) buildLogsToLagoonLogs(ctx context.Context,
 	opLog logr.Logger,
 	lagoonBuild *lagoonv1beta1.LagoonBuild,
 	logs []byte,
-	cancelled bool,
+	buildCondition lagoonv1beta1.BuildStatusType,
 ) {
 	if r.EnableMQ {
-		condition := "pending" //@TODO: remove this and uncomment the queued condition when lagoon supports queued status
-		// condition := "queued"
+		condition := buildCondition
 		buildStep := "queued"
-		if cancelled {
-			condition = "cancelled"
+		if condition == lagoonv1beta1.BuildStatusCancelled {
 			buildStep = "cancelled"
 		}
 		msg := lagoonv1beta1.LagoonLog{
@@ -243,8 +241,8 @@ func (r *LagoonBuildReconciler) buildLogsToLagoonLogs(ctx context.Context,
 			Meta: &lagoonv1beta1.LagoonLogMeta{
 				JobName:     lagoonBuild.ObjectMeta.Name, // @TODO: remove once lagoon is corrected in controller-handler
 				BuildName:   lagoonBuild.ObjectMeta.Name,
-				BuildPhase:  condition, // @TODO: same as buildstatus label, remove once lagoon is corrected in controller-handler
-				BuildStatus: condition, // same as buildstatus label
+				BuildPhase:  buildCondition.ToLower(), // @TODO: same as buildstatus label, remove once lagoon is corrected in controller-handler
+				BuildStatus: buildCondition.ToLower(), // same as buildstatus label
 				BuildStep:   buildStep,
 				BranchName:  lagoonBuild.Spec.Project.Environment,
 				RemoteID:    string(lagoonBuild.ObjectMeta.UID),
@@ -280,7 +278,7 @@ func (r *LagoonBuildReconciler) updateDeploymentAndEnvironmentTask(ctx context.C
 	opLog logr.Logger,
 	lagoonBuild *lagoonv1beta1.LagoonBuild,
 	lagoonEnv *corev1.ConfigMap,
-	cancelled bool,
+	buildCondition lagoonv1beta1.BuildStatusType,
 ) {
 	namespace := helpers.GenerateNamespaceName(
 		lagoonBuild.Spec.Project.NamespacePattern, // the namespace pattern or `openshiftProjectPattern` from Lagoon is never received by the controller
@@ -291,18 +289,13 @@ func (r *LagoonBuildReconciler) updateDeploymentAndEnvironmentTask(ctx context.C
 		r.RandomNamespacePrefix,
 	)
 	if r.EnableMQ {
-		condition := "pending" //@TODO: remove this and uncomment the queued condition when lagoon supports queued status
-		// condition := "queued"
-		if cancelled {
-			condition = "cancelled"
-		}
 		msg := lagoonv1beta1.LagoonMessage{
 			Type:      "build",
 			Namespace: namespace,
 			Meta: &lagoonv1beta1.LagoonLogMeta{
 				Environment: lagoonBuild.Spec.Project.Environment,
 				Project:     lagoonBuild.Spec.Project.Name,
-				BuildPhase:  condition,
+				BuildPhase:  buildCondition.ToLower(),
 				BuildName:   lagoonBuild.ObjectMeta.Name,
 				LogLink:     lagoonBuild.Spec.Project.UILink,
 				RemoteID:    string(lagoonBuild.ObjectMeta.UID),
@@ -376,22 +369,17 @@ func (r *LagoonBuildReconciler) buildStatusLogsToLagoonLogs(ctx context.Context,
 	opLog logr.Logger,
 	lagoonBuild *lagoonv1beta1.LagoonBuild,
 	lagoonEnv *corev1.ConfigMap,
-	cancelled bool,
+	buildCondition lagoonv1beta1.BuildStatusType,
 ) {
 	if r.EnableMQ {
-		condition := "pending" //@TODO: remove this and uncomment the queued condition when lagoon supports queued status
-		// condition := "queued"
-		if cancelled {
-			condition = "cancelled"
-		}
 		msg := lagoonv1beta1.LagoonLog{
 			Severity: "info",
 			Project:  lagoonBuild.Spec.Project.Name,
-			Event:    "task:builddeploy-kubernetes:" + condition, //@TODO: this probably needs to be changed to a new task event for the controller
+			Event:    "task:builddeploy-kubernetes:" + buildCondition.ToLower(), //@TODO: this probably needs to be changed to a new task event for the controller
 			Meta: &lagoonv1beta1.LagoonLogMeta{
 				ProjectName: lagoonBuild.Spec.Project.Name,
 				BranchName:  lagoonBuild.Spec.Project.Environment,
-				BuildPhase:  condition,
+				BuildPhase:  buildCondition.ToLower(),
 				BuildName:   lagoonBuild.ObjectMeta.Name,
 				LogLink:     lagoonBuild.Spec.Project.UILink,
 				Cluster:     r.LagoonTargetName,
@@ -400,7 +388,7 @@ func (r *LagoonBuildReconciler) buildStatusLogsToLagoonLogs(ctx context.Context,
 				lagoonBuild.Spec.Project.Name,
 				lagoonBuild.Spec.Project.Environment,
 				lagoonBuild.ObjectMeta.Name,
-				condition,
+				buildCondition.ToLower(),
 			),
 		}
 		// if we aren't being provided the lagoon config, we can skip adding the routes etc

--- a/controllers/v1beta1/build_qoshandler.go
+++ b/controllers/v1beta1/build_qoshandler.go
@@ -127,7 +127,7 @@ func (r *LagoonBuildReconciler) whichBuildNext(ctx context.Context, opLog logr.L
 				// update the build to be queued, and add a log message with the build log with the current position in the queue
 				// this position will update as builds are created/processed, so the position of a build could change depending on
 				// higher or lower priority builds being created
-				r.updateQueuedBuild(ctx, pBuild, fmt.Sprintf("This build is currently queued in position %v", (idx+1)), opLog)
+				r.updateQueuedBuild(ctx, pBuild, fmt.Sprintf("This build is currently queued in position %v/%v", (idx+1), len(pendingBuilds.Items)), opLog)
 			}
 		}
 	}

--- a/controllers/v1beta1/build_qoshandler.go
+++ b/controllers/v1beta1/build_qoshandler.go
@@ -38,7 +38,7 @@ func (r *LagoonBuildReconciler) qosBuildProcessor(ctx context.Context,
 func (r *LagoonBuildReconciler) whichBuildNext(ctx context.Context, opLog logr.Logger) error {
 	listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
 		client.MatchingLabels(map[string]string{
-			"lagoon.sh/buildStatus": string(lagoonv1beta1.BuildStatusRunning),
+			"lagoon.sh/buildStatus": lagoonv1beta1.BuildStatusRunning.String(),
 			"lagoon.sh/controller":  r.ControllerNamespace,
 		}),
 	})
@@ -56,7 +56,7 @@ func (r *LagoonBuildReconciler) whichBuildNext(ctx context.Context, opLog logr.L
 		// if there are any free slots to start a build, do that here
 		listOption = (&client.ListOptions{}).ApplyOptions([]client.ListOption{
 			client.MatchingLabels(map[string]string{
-				"lagoon.sh/buildStatus": string(lagoonv1beta1.BuildStatusPending),
+				"lagoon.sh/buildStatus": lagoonv1beta1.BuildStatusPending.String(),
 				"lagoon.sh/controller":  r.ControllerNamespace,
 			}),
 		})
@@ -95,7 +95,7 @@ func (r *LagoonBuildReconciler) whichBuildNext(ctx context.Context, opLog logr.L
 					listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
 						client.InNamespace(pBuild.ObjectMeta.Namespace),
 						client.MatchingLabels(map[string]string{
-							"lagoon.sh/buildStatus": string(lagoonv1beta1.BuildStatusRunning),
+							"lagoon.sh/buildStatus": lagoonv1beta1.BuildStatusRunning.String(),
 							"lagoon.sh/controller":  r.ControllerNamespace,
 						}),
 					})

--- a/controllers/v1beta1/build_qoshandler.go
+++ b/controllers/v1beta1/build_qoshandler.go
@@ -124,6 +124,10 @@ func (r *LagoonBuildReconciler) whichBuildNext(ctx context.Context, opLog logr.L
 						}
 					}
 				}
+				// update the build to be queued, and add a log message with the build log with the current position in the queue
+				// this position will update as builds are created/processed, so the position of a build could change depending on
+				// higher or lower priority builds being created
+				r.updateQueuedBuild(ctx, pBuild, fmt.Sprintf("This build is currently queued in position %v", (idx+1)), opLog)
 			}
 		}
 	}

--- a/controllers/v1beta1/build_standardhandler.go
+++ b/controllers/v1beta1/build_standardhandler.go
@@ -30,7 +30,7 @@ func (r *LagoonBuildReconciler) standardBuildProcessor(ctx context.Context,
 	listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
 		client.InNamespace(req.Namespace),
 		client.MatchingLabels(map[string]string{
-			"lagoon.sh/buildStatus": string(lagoonv1beta1.BuildStatusRunning),
+			"lagoon.sh/buildStatus": lagoonv1beta1.BuildStatusRunning.String(),
 			"lagoon.sh/controller":  r.ControllerNamespace,
 		}),
 	})

--- a/controllers/v1beta1/podmonitor_controller.go
+++ b/controllers/v1beta1/podmonitor_controller.go
@@ -134,7 +134,7 @@ func (r *LagoonMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		runningBuilds := &lagoonv1beta1.LagoonBuildList{}
 		listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
 			client.InNamespace(req.Namespace),
-			client.MatchingLabels(map[string]string{"lagoon.sh/buildStatus": string(lagoonv1beta1.BuildStatusRunning)}),
+			client.MatchingLabels(map[string]string{"lagoon.sh/buildStatus": lagoonv1beta1.BuildStatusRunning.String()}),
 		})
 		// list all builds in the namespace that have the running buildstatus
 		if err := r.List(ctx, runningBuilds, listOption); err != nil {

--- a/controllers/v1beta1/task_controller.go
+++ b/controllers/v1beta1/task_controller.go
@@ -76,12 +76,12 @@ func (r *LagoonTaskReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// examine DeletionTimestamp to determine if object is under deletion
 	if lagoonTask.ObjectMeta.DeletionTimestamp.IsZero() {
 		// check if the task that has been recieved is a standard or advanced task
-		if lagoonTask.ObjectMeta.Labels["lagoon.sh/taskStatus"] == string(lagoonv1beta1.TaskStatusPending) &&
-			lagoonTask.ObjectMeta.Labels["lagoon.sh/taskType"] == string(lagoonv1beta1.TaskTypeStandard) {
+		if lagoonTask.ObjectMeta.Labels["lagoon.sh/taskStatus"] == lagoonv1beta1.TaskStatusPending.String() &&
+			lagoonTask.ObjectMeta.Labels["lagoon.sh/taskType"] == lagoonv1beta1.TaskTypeStandard.String() {
 			return ctrl.Result{}, r.createStandardTask(ctx, &lagoonTask, opLog)
 		}
-		if lagoonTask.ObjectMeta.Labels["lagoon.sh/taskStatus"] == string(lagoonv1beta1.TaskStatusPending) &&
-			lagoonTask.ObjectMeta.Labels["lagoon.sh/taskType"] == string(lagoonv1beta1.TaskTypeAdvanced) {
+		if lagoonTask.ObjectMeta.Labels["lagoon.sh/taskStatus"] == lagoonv1beta1.TaskStatusPending.String() &&
+			lagoonTask.ObjectMeta.Labels["lagoon.sh/taskType"] == lagoonv1beta1.TaskTypeAdvanced.String() {
 			return ctrl.Result{}, r.createAdvancedTask(ctx, &lagoonTask, opLog)
 		}
 	} else {

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -23,25 +23,27 @@ import (
 var (
 	// BuildRunningPendingStatus .
 	BuildRunningPendingStatus = []string{
-		string(lagoonv1beta1.BuildStatusPending),
-		string(lagoonv1beta1.BuildStatusRunning),
+		lagoonv1beta1.BuildStatusPending.String(),
+		lagoonv1beta1.BuildStatusQueued.String(),
+		lagoonv1beta1.BuildStatusRunning.String(),
 	}
 	// BuildCompletedCancelledFailedStatus .
 	BuildCompletedCancelledFailedStatus = []string{
-		string(lagoonv1beta1.BuildStatusFailed),
-		string(lagoonv1beta1.BuildStatusComplete),
-		string(lagoonv1beta1.BuildStatusCancelled),
+		lagoonv1beta1.BuildStatusFailed.String(),
+		lagoonv1beta1.BuildStatusComplete.String(),
+		lagoonv1beta1.BuildStatusCancelled.String(),
 	}
 	// TaskRunningPendingStatus .
 	TaskRunningPendingStatus = []string{
-		string(lagoonv1beta1.TaskStatusPending),
-		string(lagoonv1beta1.TaskStatusRunning),
+		lagoonv1beta1.TaskStatusPending.String(),
+		lagoonv1beta1.TaskStatusQueued.String(),
+		lagoonv1beta1.TaskStatusRunning.String(),
 	}
 	// TaskCompletedCancelledFailedStatus .
 	TaskCompletedCancelledFailedStatus = []string{
-		string(lagoonv1beta1.TaskStatusFailed),
-		string(lagoonv1beta1.TaskStatusComplete),
-		string(lagoonv1beta1.TaskStatusCancelled),
+		lagoonv1beta1.TaskStatusFailed.String(),
+		lagoonv1beta1.TaskStatusComplete.String(),
+		lagoonv1beta1.TaskStatusCancelled.String(),
 	}
 )
 
@@ -221,7 +223,7 @@ func VariableExists(vars *[]LagoonEnvironmentVariable, name, value string) bool 
 func CancelExtraBuilds(ctx context.Context, r client.Client, opLog logr.Logger, pendingBuilds *lagoonv1beta1.LagoonBuildList, ns string, status string) error {
 	listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
 		client.InNamespace(ns),
-		client.MatchingLabels(map[string]string{"lagoon.sh/buildStatus": string(lagoonv1beta1.BuildStatusPending)}),
+		client.MatchingLabels(map[string]string{"lagoon.sh/buildStatus": lagoonv1beta1.BuildStatusPending.String()}),
 	})
 	if err := r.List(ctx, pendingBuilds, listOption); err != nil {
 		return fmt.Errorf("Unable to list builds in the namespace, there may be none or something went wrong: %v", err)
@@ -240,7 +242,7 @@ func CancelExtraBuilds(ctx context.Context, r client.Client, opLog logr.Logger, 
 			} else {
 				// cancel any other pending builds
 				opLog.Info(fmt.Sprintf("Setting build %s as cancelled", pendingBuild.ObjectMeta.Name))
-				pendingBuild.Labels["lagoon.sh/buildStatus"] = string(lagoonv1beta1.BuildStatusCancelled)
+				pendingBuild.Labels["lagoon.sh/buildStatus"] = lagoonv1beta1.BuildStatusCancelled.String()
 				pendingBuild.Labels["lagoon.sh/cancelledByNewBuild"] = "true"
 			}
 			if err := r.Update(ctx, pendingBuild); err != nil {

--- a/internal/messenger/consumer.go
+++ b/internal/messenger/consumer.go
@@ -257,8 +257,8 @@ func (m *Messenger) Consumer(targetName string) { //error {
 			job.ObjectMeta.Namespace = namespace
 			job.SetLabels(
 				map[string]string{
-					"lagoon.sh/taskType":   string(lagoonv1beta1.TaskTypeStandard),
-					"lagoon.sh/taskStatus": string(lagoonv1beta1.TaskStatusPending),
+					"lagoon.sh/taskType":   lagoonv1beta1.TaskTypeStandard.String(),
+					"lagoon.sh/taskStatus": lagoonv1beta1.TaskStatusPending.String(),
 					"lagoon.sh/controller": m.ControllerNamespace,
 				},
 			)

--- a/internal/messenger/tasks_handler.go
+++ b/internal/messenger/tasks_handler.go
@@ -43,7 +43,7 @@ func (m *Messenger) CancelBuild(namespace string, jobSpec *lagoonv1beta1.LagoonT
 		}
 		// as there is no build pod, but there is a lagoon build resource
 		// update it to cancelled so that the controller doesn't try to run it
-		lagoonBuild.ObjectMeta.Labels["lagoon.sh/buildStatus"] = string(lagoonv1beta1.BuildStatusCancelled)
+		lagoonBuild.ObjectMeta.Labels["lagoon.sh/buildStatus"] = lagoonv1beta1.BuildStatusCancelled.String()
 		lagoonBuild.ObjectMeta.Labels["lagoon.sh/cancelBuildNoPod"] = "true"
 		if err := m.Client.Update(context.Background(), &lagoonBuild); err != nil {
 			opLog.Error(err,
@@ -100,7 +100,7 @@ func (m *Messenger) CancelTask(namespace string, jobSpec *lagoonv1beta1.LagoonTa
 		}
 		// as there is no task pod, but there is a lagoon task resource
 		// update it to cancelled so that the controller doesn't try to run it
-		lagoonTask.ObjectMeta.Labels["lagoon.sh/taskStatus"] = string(lagoonv1beta1.TaskStatusCancelled)
+		lagoonTask.ObjectMeta.Labels["lagoon.sh/taskStatus"] = lagoonv1beta1.TaskStatusCancelled.String()
 		if err := m.Client.Update(context.Background(), &lagoonTask); err != nil {
 			opLog.Error(err,
 				fmt.Sprintf(
@@ -216,8 +216,8 @@ func createAdvancedTask(namespace string, jobSpec *lagoonv1beta1.LagoonTaskSpec,
 			Name:      "lagoon-advanced-task-" + helpers.RandString(6),
 			Namespace: namespace,
 			Labels: map[string]string{
-				"lagoon.sh/taskType":   string(lagoonv1beta1.TaskTypeAdvanced),
-				"lagoon.sh/taskStatus": string(lagoonv1beta1.TaskStatusPending),
+				"lagoon.sh/taskType":   lagoonv1beta1.TaskTypeAdvanced.String(),
+				"lagoon.sh/taskStatus": lagoonv1beta1.TaskStatusPending.String(),
 				"lagoon.sh/controller": m.ControllerNamespace,
 			},
 		},


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

This adds a log message to any builds that are currently in the queue for QoS, and updates their status to `pending`. Once https://github.com/uselagoon/lagoon/pull/3351 is supported in lagoon, this can be updated to use `queued` instead.
