### PR TITLE
chore: support new key type for deploytarget

### DIFF
--- a/controller-test.sh
+++ b/controller-test.sh
@@ -273,7 +273,7 @@ echo '
         \"misc\":{
             \"miscResource\":\"eyJhcGlWZXJzaW9uIjoiYmFja3VwLmFwcHVpby5jaC92MWFscGhhMSIsImtpbmQiOiJSZXN0b3JlIiwibWV0YWRhdGEiOnsibmFtZSI6InJlc3RvcmUtYmYwNzJhMC11cXhxbzMifSwic3BlYyI6eyJzbmFwc2hvdCI6ImJmMDcyYTA5ZTE3NzI2ZGE1NGFkYzc5OTM2ZWM4NzQ1NTIxOTkzNTk5ZDQxMjExZGZjOTQ2NmRmZDViYzMyYTUiLCJyZXN0b3JlTWV0aG9kIjp7InMzIjp7fX0sImJhY2tlbmQiOnsiczMiOnsiYnVja2V0IjoiYmFhcy1uZ2lueC1leGFtcGxlIn0sInJlcG9QYXNzd29yZFNlY3JldFJlZiI6eyJrZXkiOiJyZXBvLXB3IiwibmFtZSI6ImJhYXMtcmVwby1wdyJ9fX19\"
         },
-        \"key\":\"kubernetes:restic:backup:restore\",
+        \"key\":\"deploytarget:restic:backup:restore\",
         \"environment\":{
             \"name\":\"main\",
             \"openshiftProjectName\":\"nginx-example-main\"
@@ -332,7 +332,7 @@ echo '
         \"misc\":{
             \"miscResource\":\"eyJtZXRhZGF0YSI6eyJuYW1lIjoicmVzdG9yZS1iZjA3MmEwLXVxeHFvNCJ9LCJzcGVjIjp7InNuYXBzaG90IjoiYmYwNzJhMDllMTc3MjZkYTU0YWRjNzk5MzZlYzg3NDU1MjE5OTM1OTlkNDEyMTFkZmM5NDY2ZGZkNWJjMzJhNSIsInJlc3RvcmVNZXRob2QiOnsiczMiOnt9fSwiYmFja2VuZCI6eyJzMyI6eyJidWNrZXQiOiJiYWFzLW5naW54LWV4YW1wbGUifSwicmVwb1Bhc3N3b3JkU2VjcmV0UmVmIjp7ImtleSI6InJlcG8tcHciLCJuYW1lIjoiYmFhcy1yZXBvLXB3In19fX0=\"
         },
-        \"key\":\"kubernetes:restic:backup:restore\",
+        \"key\":\"deploytarget:restic:backup:restore\",
         \"environment\":{
             \"name\":\"main\",
             \"openshiftProjectName\":\"nginx-example-main\"

--- a/internal/messenger/consumer.go
+++ b/internal/messenger/consumer.go
@@ -303,7 +303,7 @@ func (m *Messenger) Consumer(targetName string) { //error {
 				m.RandomNamespacePrefix,
 			)
 			switch jobSpec.Key {
-			case "kubernetes:build:cancel":
+			case "deploytarget:build:cancel", "kubernetes:build:cancel":
 				opLog.Info(
 					fmt.Sprintf(
 						"Received build cancellation for project %s, environment %s - %s",
@@ -318,7 +318,7 @@ func (m *Messenger) Consumer(targetName string) { //error {
 					message.Ack(false) // ack to remove from queue
 					return
 				}
-			case "kubernetes:task:cancel":
+			case "deploytarget:task:cancel", "kubernetes:task:cancel":
 				opLog.Info(
 					fmt.Sprintf(
 						"Received task cancellation for project %s, environment %s - %s",
@@ -333,7 +333,7 @@ func (m *Messenger) Consumer(targetName string) { //error {
 					message.Ack(false) // ack to remove from queue
 					return
 				}
-			case "kubernetes:restic:backup:restore":
+			case "deploytarget:restic:backup:restore", "kubernetes:restic:backup:restore":
 				opLog.Info(
 					fmt.Sprintf(
 						"Received backup restoration for project %s, environment %s",
@@ -347,7 +347,7 @@ func (m *Messenger) Consumer(targetName string) { //error {
 					message.Ack(false) // ack to remove from queue
 					return
 				}
-			case "kubernetes:route:migrate":
+			case "deploytarget:route:migrate", "kubernetes:route:migrate", "openshift:route:migrate":
 				opLog.Info(
 					fmt.Sprintf(
 						"Received ingress migration for project %s",
@@ -360,20 +360,7 @@ func (m *Messenger) Consumer(targetName string) { //error {
 					message.Ack(false) // ack to remove from queue
 					return
 				}
-			case "openshift:route:migrate":
-				opLog.Info(
-					fmt.Sprintf(
-						"Received route migration for project %s",
-						jobSpec.Project.Name,
-					),
-				)
-				err := m.IngressRouteMigration(namespace, jobSpec)
-				if err != nil {
-					//@TODO: send msg back to lagoon and update task to failed?
-					message.Ack(false) // ack to remove from queue
-					return
-				}
-			case "kubernetes:task:advanced":
+			case "deploytarget:task:advanced", "kubernetes:task:advanced":
 				opLog.Info(
 					fmt.Sprintf(
 						"Received advanced task for project %s",


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Add support for `deploytarget:` as a key level for misc tasks in remote-controller, still support the old key types though for now
