### PR TITLE
Feature: Include node & cluster info in build logs

### DIFF
--- a/controllers/v1beta1/podmonitor_buildhandlers.go
+++ b/controllers/v1beta1/podmonitor_buildhandlers.go
@@ -170,10 +170,17 @@ func (r *LagoonMonitorReconciler) buildLogsToLagoonLogs(ctx context.Context,
 			},
 		}
 		// add the actual build log message
-		msg.Message = fmt.Sprintf(`========================================
-Logs on pod %s
+		if jobPod.Spec.NodeName != "" {
+			msg.Message = fmt.Sprintf(`================================================================================
+Logs on pod %s, assigned to node %s on cluster %s
+================================================================================
+%s`, jobPod.ObjectMeta.Name, jobPod.Spec.NodeName, r.LagoonTargetName, logs)
+		} else {
+			msg.Message = fmt.Sprintf(`========================================
+Logs on pod %s, assigned to cluster %s
 ========================================
-%s`, jobPod.ObjectMeta.Name, logs)
+%s`, jobPod.ObjectMeta.Name, r.LagoonTargetName, logs)
+		}
 		msgBytes, err := json.Marshal(msg)
 		if err != nil {
 			opLog.Error(err, "Unable to encode message as JSON")

--- a/controllers/v1beta1/podmonitor_taskhandlers.go
+++ b/controllers/v1beta1/podmonitor_taskhandlers.go
@@ -118,10 +118,17 @@ func (r *LagoonMonitorReconciler) taskLogsToLagoonLogs(opLog logr.Logger,
 				Key:         lagoonTask.Spec.Key,
 				Cluster:     r.LagoonTargetName,
 			},
-			Message: fmt.Sprintf(`========================================
-Logs on pod %s
-========================================
-%s`, jobPod.ObjectMeta.Name, logs),
+		}
+		if jobPod.Spec.NodeName != "" {
+			msg.Message = fmt.Sprintf(`================================================================================
+Logs on pod %s, assigned to node %s on cluster %s
+================================================================================
+%s`, jobPod.ObjectMeta.Name, jobPod.Spec.NodeName, r.LagoonTargetName, logs)
+		} else {
+			msg.Message = fmt.Sprintf(`================================================================================
+Logs on pod %s, assigned to cluster %s
+================================================================================
+%s`, jobPod.ObjectMeta.Name, r.LagoonTargetName, logs)
 		}
 		msgBytes, err := json.Marshal(msg)
 		if err != nil {


### PR DESCRIPTION
Addresses https://github.com/uselagoon/build-deploy-tool/issues/163

Included node & cluster information in the head of the build logs.

![image](https://user-images.githubusercontent.com/40746380/208323522-700c5acb-a68e-42ed-b6fc-eafa7ad9a38d.png)

