### PR TITLE
Remove MonitoringURLs support

### DIFF
--- a/apis/lagoon/v1beta1/lagoonmessaging_types.go
+++ b/apis/lagoon/v1beta1/lagoonmessaging_types.go
@@ -15,31 +15,30 @@ type LagoonLog struct {
 
 // LagoonLogMeta is the metadata that is used by logging in Lagoon.
 type LagoonLogMeta struct {
-	BranchName     string          `json:"branchName,omitempty"`
-	BuildName      string          `json:"buildName,omitempty"`
-	BuildPhase     string          `json:"buildPhase,omitempty"` // @TODO: deprecate once controller-handler is fixed
-	BuildStatus    string          `json:"buildStatus,omitempty"`
-	BuildStep      string          `json:"buildStep,omitempty"`
-	EndTime        string          `json:"endTime,omitempty"`
-	Environment    string          `json:"environment,omitempty"`
-	EnvironmentID  *uint           `json:"environmentId,omitempty"`
-	JobName        string          `json:"jobName,omitempty"`   // used by tasks/jobs
-	JobStatus      string          `json:"jobStatus,omitempty"` // used by tasks/jobs
-	JobStep        string          `json:"jobStep,omitempty"`   // used by tasks/jobs
-	LogLink        string          `json:"logLink,omitempty"`
-	MonitoringURLs []string        `json:"monitoringUrls,omitempty"`
-	Project        string          `json:"project,omitempty"`
-	ProjectID      *uint           `json:"projectId,omitempty"`
-	ProjectName    string          `json:"projectName,omitempty"`
-	RemoteID       string          `json:"remoteId,omitempty"`
-	Route          string          `json:"route,omitempty"`
-	Routes         []string        `json:"routes,omitempty"`
-	StartTime      string          `json:"startTime,omitempty"`
-	Services       []string        `json:"services,omitempty"`
-	Task           *LagoonTaskInfo `json:"task,omitempty"`
-	Key            string          `json:"key,omitempty"`
-	AdvancedData   string          `json:"advancedData,omitempty"`
-	Cluster        string          `json:"clusterName,omitempty"`
+	BranchName    string          `json:"branchName,omitempty"`
+	BuildName     string          `json:"buildName,omitempty"`
+	BuildPhase    string          `json:"buildPhase,omitempty"` // @TODO: deprecate once controller-handler is fixed
+	BuildStatus   string          `json:"buildStatus,omitempty"`
+	BuildStep     string          `json:"buildStep,omitempty"`
+	EndTime       string          `json:"endTime,omitempty"`
+	Environment   string          `json:"environment,omitempty"`
+	EnvironmentID *uint           `json:"environmentId,omitempty"`
+	JobName       string          `json:"jobName,omitempty"`   // used by tasks/jobs
+	JobStatus     string          `json:"jobStatus,omitempty"` // used by tasks/jobs
+	JobStep       string          `json:"jobStep,omitempty"`   // used by tasks/jobs
+	LogLink       string          `json:"logLink,omitempty"`
+	Project       string          `json:"project,omitempty"`
+	ProjectID     *uint           `json:"projectId,omitempty"`
+	ProjectName   string          `json:"projectName,omitempty"`
+	RemoteID      string          `json:"remoteId,omitempty"`
+	Route         string          `json:"route,omitempty"`
+	Routes        []string        `json:"routes,omitempty"`
+	StartTime     string          `json:"startTime,omitempty"`
+	Services      []string        `json:"services,omitempty"`
+	Task          *LagoonTaskInfo `json:"task,omitempty"`
+	Key           string          `json:"key,omitempty"`
+	AdvancedData  string          `json:"advancedData,omitempty"`
+	Cluster       string          `json:"clusterName,omitempty"`
 }
 
 // LagoonMessage is used for sending build info back to Lagoon

--- a/apis/lagoon/v1beta1/zz_generated.deepcopy.go
+++ b/apis/lagoon/v1beta1/zz_generated.deepcopy.go
@@ -226,11 +226,6 @@ func (in *LagoonLogMeta) DeepCopyInto(out *LagoonLogMeta) {
 		*out = new(uint)
 		**out = **in
 	}
-	if in.MonitoringURLs != nil {
-		in, out := &in.MonitoringURLs, &out.MonitoringURLs
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	if in.ProjectID != nil {
 		in, out := &in.ProjectID, &out.ProjectID
 		*out = new(uint)

--- a/config/crd/bases/crd.lagoon.sh_lagoonbuilds.yaml
+++ b/config/crd/bases/crd.lagoon.sh_lagoonbuilds.yaml
@@ -240,10 +240,6 @@ spec:
                         type: string
                       logLink:
                         type: string
-                      monitoringUrls:
-                        items:
-                          type: string
-                        type: array
                       project:
                         type: string
                       projectId:
@@ -333,10 +329,6 @@ spec:
                         type: string
                       logLink:
                         type: string
-                      monitoringUrls:
-                        items:
-                          type: string
-                        type: array
                       project:
                         type: string
                       projectId:
@@ -428,10 +420,6 @@ spec:
                         type: string
                       logLink:
                         type: string
-                      monitoringUrls:
-                        items:
-                          type: string
-                        type: array
                       project:
                         type: string
                       projectId:
@@ -525,10 +513,6 @@ spec:
                         type: string
                       logLink:
                         type: string
-                      monitoringUrls:
-                        items:
-                          type: string
-                        type: array
                       project:
                         type: string
                       projectId:

--- a/config/crd/bases/crd.lagoon.sh_lagoontasks.yaml
+++ b/config/crd/bases/crd.lagoon.sh_lagoontasks.yaml
@@ -211,10 +211,6 @@ spec:
                         type: string
                       logLink:
                         type: string
-                      monitoringUrls:
-                        items:
-                          type: string
-                        type: array
                       project:
                         type: string
                       projectId:
@@ -304,10 +300,6 @@ spec:
                         type: string
                       logLink:
                         type: string
-                      monitoringUrls:
-                        items:
-                          type: string
-                        type: array
                       project:
                         type: string
                       projectId:
@@ -399,10 +391,6 @@ spec:
                         type: string
                       logLink:
                         type: string
-                      monitoringUrls:
-                        items:
-                          type: string
-                        type: array
                       project:
                         type: string
                       projectId:
@@ -496,10 +484,6 @@ spec:
                         type: string
                       logLink:
                         type: string
-                      monitoringUrls:
-                        items:
-                          type: string
-                        type: array
                       project:
                         type: string
                       projectId:

--- a/controllers/v1beta1/build_deletionhandlers.go
+++ b/controllers/v1beta1/build_deletionhandlers.go
@@ -337,10 +337,6 @@ func (r *LagoonBuildReconciler) updateDeploymentAndEnvironmentTask(ctx context.C
 			if routes, ok := lagoonEnv.Data["LAGOON_ROUTES"]; ok {
 				msg.Meta.Routes = strings.Split(routes, ",")
 			}
-			msg.Meta.MonitoringURLs = []string{}
-			if monitoringUrls, ok := lagoonEnv.Data["LAGOON_MONITORING_URLS"]; ok {
-				msg.Meta.MonitoringURLs = strings.Split(monitoringUrls, ",")
-			}
 		}
 		msg.Meta.StartTime = time.Now().UTC().Format("2006-01-02 15:04:05")
 		msg.Meta.EndTime = time.Now().UTC().Format("2006-01-02 15:04:05")
@@ -400,10 +396,6 @@ func (r *LagoonBuildReconciler) buildStatusLogsToLagoonLogs(ctx context.Context,
 			msg.Meta.Routes = []string{}
 			if routes, ok := lagoonEnv.Data["LAGOON_ROUTES"]; ok {
 				msg.Meta.Routes = strings.Split(routes, ",")
-			}
-			msg.Meta.MonitoringURLs = []string{}
-			if monitoringUrls, ok := lagoonEnv.Data["LAGOON_MONITORING_URLS"]; ok {
-				msg.Meta.MonitoringURLs = strings.Split(monitoringUrls, ",")
 			}
 		}
 		msgBytes, err := json.Marshal(msg)

--- a/controllers/v1beta1/podmonitor_buildhandlers.go
+++ b/controllers/v1beta1/podmonitor_buildhandlers.go
@@ -294,10 +294,6 @@ func (r *LagoonMonitorReconciler) updateDeploymentAndEnvironmentTask(ctx context
 			if routes, ok := lagoonEnv.Data["LAGOON_ROUTES"]; ok {
 				msg.Meta.Routes = strings.Split(routes, ",")
 			}
-			msg.Meta.MonitoringURLs = []string{}
-			if monitoringUrls, ok := lagoonEnv.Data["LAGOON_MONITORING_URLS"]; ok {
-				msg.Meta.MonitoringURLs = strings.Split(monitoringUrls, ",")
-			}
 		}
 		// we can add the build start time here
 		if jobPod.Status.StartTime != nil {
@@ -393,10 +389,6 @@ func (r *LagoonMonitorReconciler) buildStatusLogsToLagoonLogs(ctx context.Contex
 			if routes, ok := lagoonEnv.Data["LAGOON_ROUTES"]; ok {
 				msg.Meta.Routes = strings.Split(routes, ",")
 				addRoutes = fmt.Sprintf("\n%s", strings.Join(strings.Split(routes, ","), "\n"))
-			}
-			msg.Meta.MonitoringURLs = []string{}
-			if monitoringUrls, ok := lagoonEnv.Data["LAGOON_MONITORING_URLS"]; ok {
-				msg.Meta.MonitoringURLs = strings.Split(monitoringUrls, ",")
 			}
 		}
 		msg.Message = fmt.Sprintf("*[%s]* `%s` Build `%s` %s <%s|Logs>%s%s",


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

The monitoring urls feature hasn't been used for awhile, as it was replaced with monitoring paths. The api will stop storing this information soon, so there is no need to send it back.

# Closing issues

Part of https://github.com/uselagoon/lagoon/issues/2975