### PR TITLE
fix: actually update pending or queued builds

### DIFF
--- a/controllers/v1beta1/build_helpers.go
+++ b/controllers/v1beta1/build_helpers.go
@@ -864,6 +864,9 @@ func (r *LagoonBuildReconciler) updateQueuedBuild(
 	message string,
 	opLog logr.Logger,
 ) error {
+	if r.EnableDebug {
+		opLog.Info(fmt.Sprintf("Updating build %s to queued: %s", lagoonBuild.ObjectMeta.Name, message))
+	}
 	var allContainerLogs []byte
 	// if we get this handler, then it is likely that the build was in a pending or running state with no actual running pod
 	// so just set the logs to be cancellation message


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

When checking pending builds, there was a case where the controller would not update pending builds as pending or queued because the build process was returning due to another function.

Also some additional debug messaging if required

# Closing issues

closes #200