### PR TITLE
feat: add dynamic secrets to task controller

### DIFF
--- a/controller-test.sh
+++ b/controller-test.sh
@@ -206,7 +206,8 @@ echo "==> Trigger a Task using kubectl apply to test dynamic secret mounting"
 kubectl -n $NS apply -f test-resources/dynamic-secret-in-task-project1-secret.yaml
 kubectl -n $NS apply -f test-resources/dynamic-secret-in-task-project1.yaml
 kubectl -n $NS patch lagoontasks.crd.lagoon.sh lagoon-advanced-task-example-task-project-1 --type=merge --patch '{"metadata":{"labels":{"lagoon.sh/controller":"'$CONTROLLER_NAMESPACE'"}}}'
-kubectl get lagoontasks lagoon-advanced-task-example-task-project-1 -n $NS -o yaml
+kubectl -n $NS patch lagoontasks.crd.lagoon.sh lagoon-advanced-task-example-task-project-1 --type=merge --patch '{"metadata":{"labels":{"bump":"bump"}}}'
+#kubectl get lagoontasks lagoon-advanced-task-example-task-project-1 -n $NS -o yaml
 
 # wait on pod creation
 wait_for_task_pod_to_complete lagoon-advanced-task-example-task-project-1

--- a/controller-test.sh
+++ b/controller-test.sh
@@ -206,7 +206,7 @@ echo "==> Trigger a Task using kubectl apply to test dynamic secret mounting"
 kubectl -n $NS apply -f test-resources/dynamic-secret-in-task-project1-secret.yaml
 kubectl -n $NS apply -f test-resources/dynamic-secret-in-task-project1.yaml
 kubectl -n $NS patch lagoontasks.crd.lagoon.sh lagoon-advanced-task-example-task-project-1 --type=merge --patch '{"metadata":{"labels":{"lagoon.sh/controller":"'$CONTROLLER_NAMESPACE'"}}}'
-#kubectl get lagoontasks -A
+kubectl get lagoontasks -A
 
 # wait on pod creation
 wait_for_task_pod_to_complete lagoon-advanced-task-example-task-project-1

--- a/controller-test.sh
+++ b/controller-test.sh
@@ -206,7 +206,7 @@ echo "==> Trigger a Task using kubectl apply to test dynamic secret mounting"
 kubectl -n $NS apply -f test-resources/dynamic-secret-in-task-project1-secret.yaml
 kubectl -n $NS apply -f test-resources/dynamic-secret-in-task-project1.yaml
 kubectl -n $NS patch lagoontasks.crd.lagoon.sh lagoon-advanced-task-example-task-project-1 --type=merge --patch '{"metadata":{"labels":{"lagoon.sh/controller":"'$CONTROLLER_NAMESPACE'"}}}'
-kubectl get lagoontasks -A
+kubectl get lagoontasks lagoon-advanced-task-example-task-project-1 -n $NS -o yaml
 
 # wait on pod creation
 wait_for_task_pod_to_complete lagoon-advanced-task-example-task-project-1

--- a/controller-test.sh
+++ b/controller-test.sh
@@ -121,6 +121,8 @@ wait_for_task_pod_to_complete () {
     echo "==> Check task progress"
     until $(kubectl -n ${NS} get pods ${1} --no-headers | grep -iq "Completed")
     do
+    echo "=====> Pods in ns ${NS}:"
+    kubectl -n ${NS} get pods ${1} --no-headers
     if [ $CHECK_COUNTER -lt $CHECK_TIMEOUT ]; then
         let CHECK_COUNTER=CHECK_COUNTER+1
         echo "==> Task not completed yet"

--- a/controller-test.sh
+++ b/controller-test.sh
@@ -111,6 +111,35 @@ build_deploy_controller () {
     echo "==> Controller is running"
 }
 
+clean_task_test_resources() {
+  kubectl -n $NS delete -f test-resources/dynamic-secret-in-task-project1.yaml
+}
+
+wait_for_task_pod_to_complete () {
+    POD_NAME=${1}
+    CHECK_COUNTER=1
+    echo "==> Check task progress"
+    until $(kubectl -n ${NS} get pods ${1} --no-headers | grep -iq "Completed")
+    do
+    if [ $CHECK_COUNTER -lt $CHECK_TIMEOUT ]; then
+        let CHECK_COUNTER=CHECK_COUNTER+1
+        echo "==> Task not completed yet"
+        sleep 5
+    else
+        echo "Timeout of $CHECK_TIMEOUT waiting for task to complete"
+        echo "=========== TASK LOG ============"
+        kubectl -n ${NS} logs ${1} -f
+        clean_task_test_resources
+        check_controller_log ${1}
+        tear_down
+        echo "================ END ================"
+        echo "============== FAILED ==============="
+        exit 1
+    fi
+    done
+    echo "==> Task completed"
+}
+
 
 check_lagoon_build () {
     CHECK_COUNTER=1
@@ -168,6 +197,27 @@ kubectl -n $CONTROLLER_NAMESPACE patch lagoonbuilds.crd.lagoon.sh lagoon-build-$
 kubectl -n $CONTROLLER_NAMESPACE patch lagoonbuilds.crd.lagoon.sh lagoon-build-${LBUILD} --type=merge --patch '{"metadata":{"labels":{"bump":"bump"}}}'
 sleep 10
 check_lagoon_build lagoon-build-${LBUILD}
+
+echo "==> Trigger a Task using kubectl apply to test dynamic secret mounting"
+
+kubectl -n $NS apply -f test-resources/dynamic-secret-in-task-project1.yaml
+
+# wait on pod creation
+wait_for_task_pod_to_complete example-task-project-1
+VMDATA=$(kubectl get pod -n nginx-example-main example-task-project-1 -o jsonpath='{.spec.containers[0].volumeMounts}' | jq -r '.[] | select(.name == "dynamic-test-dynamic-secret") | .mountPath')
+
+if [ ! "$VMDATA" = "/var/run/secrets/lagoon/dynamic/test-dynamic-secret" ]; then
+    echo "==> Task failed to mount dynamic secret"
+    clean_task_test_resources
+    check_controller_log ${1}
+    tear_down
+    echo "============== FAILED ==============="
+    exit 1
+  else
+    echo "==> Dynamic secret mounting into tasks good"
+    clean_task_test_resources
+fi
+
 
 echo "==> Trigger a lagoon build using rabbitmq"
 echo '

--- a/test-resources/dynamic-secret-in-task-project1-secret.yaml
+++ b/test-resources/dynamic-secret-in-task-project1-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  secret1: YmxhaCBibGFoIGJsYWg=
+kind: Secret
+metadata:
+  labels:
+    lagoon.sh/dynamic-secret: "true"
+  name: test-dynamic-secret
+type: Opaque

--- a/test-resources/dynamic-secret-in-task-project1.yaml
+++ b/test-resources/dynamic-secret-in-task-project1.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+data:
+  secret1: YmxhaCBibGFoIGJsYWg=
+kind: Secret
+metadata:
+  labels:
+    lagoon.sh/dynamic-secret: "true"
+  name: test-dynamic-secret
+  namespace: nginx-example-main
+type: Opaque
+---
+apiVersion: crd.lagoon.sh/v1beta1
+kind: LagoonTask
+metadata:
+  name: "example-task-project-1"
+  namespace: "nginx-example-main"
+  labels:
+    lagoon.sh/controller: lagoon
+    lagoon.sh/taskStatus: Pending
+    lagoon.sh/taskType: advanced
+    lagoon.sh/jobType: task
+spec:
+  advancedTask:
+    JSONPayload: >-
+      e30K
+    deployerToken: false
+    runnerImage: hello-world
+    sshKey: false
+  environment:
+    environmentType: ''
+    id: ''
+    name: main
+    project: ngnix-example
+  key: kubernetes:route:migrate
+  misc:
+    id: ''
+  project:
+    id: ''
+    name: nginx-example
+  task:
+    id: '1'
+    name: Example Task Project 1

--- a/test-resources/dynamic-secret-in-task-project1.yaml
+++ b/test-resources/dynamic-secret-in-task-project1.yaml
@@ -1,28 +1,14 @@
-apiVersion: v1
-data:
-  secret1: YmxhaCBibGFoIGJsYWg=
-kind: Secret
-metadata:
-  labels:
-    lagoon.sh/dynamic-secret: "true"
-  name: test-dynamic-secret
-  namespace: nginx-example-main
-type: Opaque
----
 apiVersion: crd.lagoon.sh/v1beta1
 kind: LagoonTask
 metadata:
-  name: "example-task-project-1"
-  namespace: "nginx-example-main"
+  name: "lagoon-advanced-task-example-task-project-1"
   labels:
     lagoon.sh/controller: lagoon
     lagoon.sh/taskStatus: Pending
     lagoon.sh/taskType: advanced
-    lagoon.sh/jobType: task
 spec:
   advancedTask:
-    JSONPayload: >-
-      e30K
+    JSONPayload: e30=
     deployerToken: false
     runnerImage: hello-world
     sshKey: false
@@ -39,4 +25,4 @@ spec:
     name: nginx-example
   task:
     id: '1'
-    name: Example Task Project 1
+    name: lagoon-task-1234


### PR DESCRIPTION
In https://github.com/uselagoon/build-deploy-tool/pull/148 we added the ability to mount dynamic secrets into the build.
This needs to be duplicated for advanced tasks - and so this replicates the logic found in the build-deploy legacy tooling.

# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Explain the **details** for making this change. What existing problem does the pull request solve?