### PR TITLE
feat: support being able to force rotate robot account credentials

### DIFF
--- a/controllers/v1beta1/build_helpers.go
+++ b/controllers/v1beta1/build_helpers.go
@@ -218,7 +218,8 @@ func (r *LagoonBuildReconciler) getOrCreateNamespace(ctx context.Context, namesp
 				hProject,
 				lagoonBuild.Spec.Project.Environment,
 				ns,
-				lagoonHarbor.RobotAccountExpiry)
+				lagoonHarbor.RobotAccountExpiry,
+				false)
 			if err != nil {
 				return fmt.Errorf("Error creating harbor robot account: %v", err)
 			}
@@ -233,21 +234,20 @@ func (r *LagoonBuildReconciler) getOrCreateNamespace(ctx context.Context, namesp
 				hProject,
 				lagoonBuild.Spec.Project.Environment,
 				ns,
-				time.Now().Add(lagoonHarbor.RobotAccountExpiry).Unix())
+				time.Now().Add(lagoonHarbor.RobotAccountExpiry).Unix(),
+				false)
 			if err != nil {
 				return fmt.Errorf("Error creating harbor robot account: %v", err)
 			}
 		}
-		if robotCreds != nil {
-			// if we have robotcredentials to create, do that here
-			if err := harbor.UpsertHarborSecret(ctx,
-				r.Client,
-				ns,
-				"lagoon-internal-registry-secret",
-				lagoonHarbor.Hostname,
-				robotCreds); err != nil {
-				return fmt.Errorf("Error upserting harbor robot account secret: %v", err)
-			}
+		// if we have robotcredentials to create, do that here
+		_, err = lagoonHarbor.UpsertHarborSecret(ctx,
+			r.Client,
+			ns,
+			"lagoon-internal-registry-secret",
+			robotCreds)
+		if err != nil {
+			return fmt.Errorf("Error upserting harbor robot account secret: %v", err)
 		}
 	}
 	return nil

--- a/controllers/v1beta1/harborcredential_controller.go
+++ b/controllers/v1beta1/harborcredential_controller.go
@@ -1,0 +1,83 @@
+package v1beta1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/uselagoon/remote-controller/internal/harbor"
+	"github.com/uselagoon/remote-controller/internal/helpers"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// HarborCredentialReconciler reconciles a namespace object
+type HarborCredentialReconciler struct {
+	client.Client
+	Log                 logr.Logger
+	Scheme              *runtime.Scheme
+	LFFHarborEnabled    bool
+	Harbor              harbor.Harbor
+	ControllerNamespace string
+}
+
+// all the things
+// +kubebuilder:rbac:groups=*,resources=*,verbs=*
+
+func (r *HarborCredentialReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	opLog := r.Log.WithValues("harbor", req.NamespacedName)
+
+	var harborSecret corev1.Secret
+	if err := r.Get(ctx, req.NamespacedName, &harborSecret); err != nil {
+		return ctrl.Result{}, helpers.IgnoreNotFound(err)
+	}
+
+	// check if the credentials need to be force rotated
+	value, ok := harborSecret.ObjectMeta.Labels["harbor.lagoon.sh/force-rotate"]
+	if ok && value == "true" {
+		opLog.Info(fmt.Sprintf("Rotating harbor credentials for namespace %s", harborSecret.ObjectMeta.Namespace))
+		lagoonHarbor, err := harbor.New(r.Harbor)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("Error creating harbor client, check your harbor configuration. Error was: %v", err)
+		}
+		var ns corev1.Namespace
+		if err := r.Get(ctx, types.NamespacedName{Name: harborSecret.ObjectMeta.Namespace}, &ns); err != nil {
+			return ctrl.Result{}, helpers.IgnoreNotFound(err)
+		}
+		rotated, err := lagoonHarbor.RotateRobotCredential(ctx, r.Client, ns, true)
+		if err != nil {
+			// @TODO: resource unknown
+			return ctrl.Result{}, fmt.Errorf("Error was: %v", err)
+		}
+		if rotated {
+			opLog.Info(fmt.Sprintf("Robot credentials rotated for %s", ns.ObjectMeta.Name))
+		}
+		mergePatch, _ := json.Marshal(map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"labels": map[string]interface{}{
+					"harbor.lagoon.sh/force-rotate": nil,
+				},
+			},
+		})
+		if err := r.Patch(ctx, &harborSecret, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("There was an error patching the harbor secret. Error was: %v", err)
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the watch on the namespace resource with an event filter (see controller_predicates.go)
+func (r *HarborCredentialReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Secret{}).
+		WithEventFilter(SecretPredicates{
+			ControllerNamespace: r.ControllerNamespace,
+		}).
+		Complete(r)
+}

--- a/controllers/v1beta1/predicates.go
+++ b/controllers/v1beta1/predicates.go
@@ -248,15 +248,6 @@ func (n SecretPredicates) Create(e event.CreateEvent) bool {
 
 // Delete is used when a deletion event is received by the controller.
 func (n SecretPredicates) Delete(e event.DeleteEvent) bool {
-	if controller, ok := e.Object.GetLabels()["lagoon.sh/controller"]; ok {
-		if controller == n.ControllerNamespace {
-			if val, ok := e.Object.GetLabels()["lagoon.sh/harbor-credential"]; ok {
-				if val == "true" {
-					return true
-				}
-			}
-		}
-	}
 	return false
 }
 

--- a/controllers/v1beta1/predicates.go
+++ b/controllers/v1beta1/predicates.go
@@ -225,3 +225,49 @@ func (t TaskPredicates) Generic(e event.GenericEvent) bool {
 	}
 	return false
 }
+
+// SecretPredicates defines the funcs for predicates
+type SecretPredicates struct {
+	predicate.Funcs
+	ControllerNamespace string
+}
+
+// Create is used when a creation event is received by the controller.
+func (n SecretPredicates) Create(e event.CreateEvent) bool {
+	if controller, ok := e.Object.GetLabels()["lagoon.sh/controller"]; ok {
+		if controller == n.ControllerNamespace {
+			return true
+		}
+	}
+	return false
+}
+
+// Delete is used when a deletion event is received by the controller.
+func (n SecretPredicates) Delete(e event.DeleteEvent) bool {
+	if controller, ok := e.Object.GetLabels()["lagoon.sh/controller"]; ok {
+		if controller == n.ControllerNamespace {
+			return true
+		}
+	}
+	return false
+}
+
+// Update is used when an update event is received by the controller.
+func (n SecretPredicates) Update(e event.UpdateEvent) bool {
+	if controller, ok := e.ObjectOld.GetLabels()["lagoon.sh/controller"]; ok {
+		if controller == n.ControllerNamespace {
+			return true
+		}
+	}
+	return false
+}
+
+// Generic is used when any other event is received by the controller.
+func (n SecretPredicates) Generic(e event.GenericEvent) bool {
+	if controller, ok := e.Object.GetLabels()["lagoon.sh/controller"]; ok {
+		if controller == n.ControllerNamespace {
+			return true
+		}
+	}
+	return false
+}

--- a/controllers/v1beta1/predicates.go
+++ b/controllers/v1beta1/predicates.go
@@ -236,7 +236,11 @@ type SecretPredicates struct {
 func (n SecretPredicates) Create(e event.CreateEvent) bool {
 	if controller, ok := e.Object.GetLabels()["lagoon.sh/controller"]; ok {
 		if controller == n.ControllerNamespace {
-			return true
+			if val, ok := e.Object.GetLabels()["lagoon.sh/harbor-credential"]; ok {
+				if val == "true" {
+					return true
+				}
+			}
 		}
 	}
 	return false
@@ -246,7 +250,11 @@ func (n SecretPredicates) Create(e event.CreateEvent) bool {
 func (n SecretPredicates) Delete(e event.DeleteEvent) bool {
 	if controller, ok := e.Object.GetLabels()["lagoon.sh/controller"]; ok {
 		if controller == n.ControllerNamespace {
-			return true
+			if val, ok := e.Object.GetLabels()["lagoon.sh/harbor-credential"]; ok {
+				if val == "true" {
+					return true
+				}
+			}
 		}
 	}
 	return false
@@ -256,7 +264,11 @@ func (n SecretPredicates) Delete(e event.DeleteEvent) bool {
 func (n SecretPredicates) Update(e event.UpdateEvent) bool {
 	if controller, ok := e.ObjectOld.GetLabels()["lagoon.sh/controller"]; ok {
 		if controller == n.ControllerNamespace {
-			return true
+			if val, ok := e.ObjectOld.GetLabels()["lagoon.sh/harbor-credential"]; ok {
+				if val == "true" {
+					return true
+				}
+			}
 		}
 	}
 	return false
@@ -266,7 +278,11 @@ func (n SecretPredicates) Update(e event.UpdateEvent) bool {
 func (n SecretPredicates) Generic(e event.GenericEvent) bool {
 	if controller, ok := e.Object.GetLabels()["lagoon.sh/controller"]; ok {
 		if controller == n.ControllerNamespace {
-			return true
+			if val, ok := e.Object.GetLabels()["lagoon.sh/harbor-credential"]; ok {
+				if val == "true" {
+					return true
+				}
+			}
 		}
 	}
 	return false

--- a/internal/harbor/harbor_helpers.go
+++ b/internal/harbor/harbor_helpers.go
@@ -129,7 +129,8 @@ func (h *Harbor) UpsertHarborSecret(ctx context.Context, cl client.Client, ns, n
 				corev1.DockerConfigJsonKey: []byte(dcjBytes),
 			}
 			secret.ObjectMeta.Labels = map[string]string{
-				"lagoon.sh/controller": h.ControllerNamespace,
+				"lagoon.sh/controller":        h.ControllerNamespace,
+				"lagoon.sh/harbor-credential": "true",
 			}
 			err := cl.Create(ctx, secret)
 			if err != nil {
@@ -156,6 +157,7 @@ func (h *Harbor) UpsertHarborSecret(ctx context.Context, cl client.Client, ns, n
 				secret.ObjectMeta.Labels = map[string]string{}
 			}
 			secret.ObjectMeta.Labels["lagoon.sh/controller"] = h.ControllerNamespace
+			secret.ObjectMeta.Labels["lagoon.sh/harbor-credential"] = "true"
 		}
 		err = cl.Update(ctx, secret)
 		if err != nil {
@@ -168,7 +170,8 @@ func (h *Harbor) UpsertHarborSecret(ctx context.Context, cl client.Client, ns, n
 			mergePatch, _ := json.Marshal(map[string]interface{}{
 				"metadata": map[string]interface{}{
 					"labels": map[string]interface{}{
-						"lagoon.sh/controller": h.ControllerNamespace,
+						"lagoon.sh/controller":        h.ControllerNamespace,
+						"lagoon.sh/harbor-credential": "true",
 					},
 				},
 			})

--- a/internal/harbor/harbor_helpers.go
+++ b/internal/harbor/harbor_helpers.go
@@ -104,7 +104,7 @@ func makeHarborSecret(credentials robotAccountCredential) helpers.RegistryCreden
 }
 
 // UpsertHarborSecret will create or update the secret in kubernetes.
-func UpsertHarborSecret(ctx context.Context, cl client.Client, ns, name, baseURL string, registryCreds *helpers.RegistryCredentials) error {
+func (h *Harbor) UpsertHarborSecret(ctx context.Context, cl client.Client, ns, name string, registryCreds *helpers.RegistryCredentials) (bool, error) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
@@ -120,31 +120,62 @@ func UpsertHarborSecret(ctx context.Context, cl client.Client, ns, name, baseURL
 		Name:      name,
 	}, secret)
 	if err != nil {
-		// if the secret doesn't exist
-		// create it
-		dcj.Registries[baseURL] = *registryCreds
+		// if registryCreds are provided, and the secret doesn't exist
+		// then create the secret
+		if registryCreds != nil {
+			dcj.Registries[h.Hostname] = *registryCreds
+			dcjBytes, _ := json.Marshal(dcj)
+			secret.Data = map[string][]byte{
+				corev1.DockerConfigJsonKey: []byte(dcjBytes),
+			}
+			secret.ObjectMeta.Labels = map[string]string{
+				"lagoon.sh/controller": h.ControllerNamespace,
+			}
+			err := cl.Create(ctx, secret)
+			if err != nil {
+				return false, fmt.Errorf("could not create secret %s/%s: %s", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name, err.Error())
+			}
+			// return true that the credential was created
+			return true, nil
+		}
+		return false, nil
+	}
+	// if registryCreds are provided, and the secret exists, then update the secret
+	// with the provided credentials
+	if registryCreds != nil {
+		json.Unmarshal([]byte(secret.Data[corev1.DockerConfigJsonKey]), &dcj)
+		// add or update the credential
+		dcj.Registries[h.Hostname] = *registryCreds
 		dcjBytes, _ := json.Marshal(dcj)
 		secret.Data = map[string][]byte{
 			corev1.DockerConfigJsonKey: []byte(dcjBytes),
 		}
-		err := cl.Create(ctx, secret)
-		if err != nil {
-			return fmt.Errorf("could not create secret %s/%s: %s", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name, err.Error())
+		// add the controller label if it doesn't exist
+		if _, ok := secret.ObjectMeta.Labels["lagoon.sh/controller"]; !ok {
+			if secret.ObjectMeta.Labels == nil {
+				secret.ObjectMeta.Labels = map[string]string{}
+			}
+			secret.ObjectMeta.Labels["lagoon.sh/controller"] = h.ControllerNamespace
 		}
-		return nil
+		err = cl.Update(ctx, secret)
+		if err != nil {
+			return false, fmt.Errorf("could not update secret: %s/%s", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
+		}
+		return true, nil
+	} else {
+		// if the secret doesn't have the controller label, patch it it
+		if _, ok := secret.ObjectMeta.Labels["lagoon.sh/controller"]; !ok {
+			mergePatch, _ := json.Marshal(map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{
+						"lagoon.sh/controller": h.ControllerNamespace,
+					},
+				},
+			})
+			if err := cl.Patch(ctx, secret, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
+				return false, fmt.Errorf("could not update secret: %s/%s", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
+			}
+		}
 	}
-	// if the secret exists
-	// update the secret with the new credentials
-	json.Unmarshal([]byte(secret.Data[corev1.DockerConfigJsonKey]), &dcj)
-	// add or update the credential
-	dcj.Registries[baseURL] = *registryCreds
-	dcjBytes, _ := json.Marshal(dcj)
-	secret.Data = map[string][]byte{
-		corev1.DockerConfigJsonKey: []byte(dcjBytes),
-	}
-	err = cl.Update(ctx, secret)
-	if err != nil {
-		return fmt.Errorf("could not update secret: %s/%s", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
-	}
-	return nil
+	return false, nil
 }

--- a/main.go
+++ b/main.go
@@ -827,6 +827,21 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "LagoonTask")
 		os.Exit(1)
 	}
+
+	// for now the namespace reconciler only needs to run if harbor is enabled so that we can watch the namespace for rotation label events
+	if lffHarborEnabled {
+		if err = (&lagoonv1beta1ctrl.HarborCredentialReconciler{
+			Client:              mgr.GetClient(),
+			Log:                 ctrl.Log.WithName("v1beta1").WithName("HarborCredentialReconciler"),
+			Scheme:              mgr.GetScheme(),
+			LFFHarborEnabled:    lffHarborEnabled,
+			ControllerNamespace: controllerNamespace,
+			Harbor:              harborConfig,
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "HarborCredentialReconciler")
+			os.Exit(1)
+		}
+	}
 	// +kubebuilder:scaffold:builder
 
 	setupLog.Info("starting lagoon metrics server")


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

The controller will now watch secrets with the `lagoon.sh/controller` label, and by adding a `harbor.lagoon.sh/force-rotate=true` label on a `lagoon-internal-registry-secret` Secret the controller will now regenerate the credentials.

# Closing issues

closes #208 (mostly)