### PR TITLE
fix: only update end time if build is complete, failed, or cancelled

### DIFF
--- a/controllers/v1beta1/build_deletionhandlers.go
+++ b/controllers/v1beta1/build_deletionhandlers.go
@@ -339,7 +339,9 @@ func (r *LagoonBuildReconciler) updateDeploymentAndEnvironmentTask(ctx context.C
 			}
 		}
 		msg.Meta.StartTime = time.Now().UTC().Format("2006-01-02 15:04:05")
-		msg.Meta.EndTime = time.Now().UTC().Format("2006-01-02 15:04:05")
+		if buildCondition.ToLower() == "failed" || buildCondition.ToLower() == "complete" || buildCondition.ToLower() == "cancelled" {
+			msg.Meta.EndTime = time.Now().UTC().Format("2006-01-02 15:04:05")
+		}
 		msgBytes, err := json.Marshal(msg)
 		if err != nil {
 			opLog.Error(err, "Unable to encode message as JSON")

--- a/controllers/v1beta1/build_deletionhandlers.go
+++ b/controllers/v1beta1/build_deletionhandlers.go
@@ -338,7 +338,6 @@ func (r *LagoonBuildReconciler) updateDeploymentAndEnvironmentTask(ctx context.C
 				msg.Meta.Routes = strings.Split(routes, ",")
 			}
 		}
-		msg.Meta.StartTime = time.Now().UTC().Format("2006-01-02 15:04:05")
 		if buildCondition.ToLower() == "failed" || buildCondition.ToLower() == "complete" || buildCondition.ToLower() == "cancelled" {
 			msg.Meta.EndTime = time.Now().UTC().Format("2006-01-02 15:04:05")
 		}


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Fixes a bug where the endtime is sent during builds when it shouldn't be.

# Closes

closes https://github.com/uselagoon/lagoon-ui/issues/124