### PR TITLE
chore: try to retain existing build information when cancelling

### DIFF
--- a/internal/messenger/tasks_handler.go
+++ b/internal/messenger/tasks_handler.go
@@ -175,11 +175,12 @@ func (m *Messenger) updateLagoonBuild(opLog logr.Logger, namespace string, jobSp
 			jTime, _ := time.Parse("2006-01-02T15:04:05Z", conditions[j].LastTransitionTime)
 			return iTime.Before(jTime)
 		})
-		// get the starting time, or fallbac to default
+		// get the starting time, or fallback to default
 		sTime, err := time.Parse("2006-01-02T15:04:05Z", conditions[0].LastTransitionTime)
 		if err == nil {
 			msg.Meta.StartTime = sTime.Format("2006-01-02 15:04:05")
 		}
+		// get the ending time, or fallback to default
 		eTime, err := time.Parse("2006-01-02T15:04:05Z", conditions[len(conditions)-1].LastTransitionTime)
 		if err == nil {
 			msg.Meta.EndTime = eTime.Format("2006-01-02 15:04:05")


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

When cancelling a build via the API, the controller will try and collect any information it can about a build if the information still exists in the remote cluster. This could be a build pod, or the lagoon-build resource itself depending on which exists.

As much information from either of these two should be retrieved when possible and sent back to the api so that the API can try to be correct.
