### PR TITLE
refactor: change up the TASK_X and LAGOON_CONFIG_X variable injection

### DIFF
--- a/controllers/v1beta1/build_controller.go
+++ b/controllers/v1beta1/build_controller.go
@@ -73,7 +73,7 @@ type LagoonBuildReconciler struct {
 	NativeCronPodMinFrequency        int
 	LagoonTargetName                 string
 	LagoonFeatureFlags               map[string]string
-	LagoonAPIConfiguration           LagoonAPIConfiguration
+	LagoonAPIConfiguration           helpers.LagoonAPIConfiguration
 	ProxyConfig                      ProxyConfig
 }
 

--- a/controllers/v1beta1/build_helpers.go
+++ b/controllers/v1beta1/build_helpers.go
@@ -439,17 +439,24 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 		// add the API and SSH endpoint configuration to environments
 		{
 			Name:  "LAGOON_CONFIG_API_HOST",
-			Value: r.LagoonAPIConfiguration.APIHost,
+			Value: helpers.GetAPIValues(r.LagoonAPIConfiguration, "LAGOON_CONFIG_API_HOST"),
+		},
+		{
+			Name:  "LAGOON_CONFIG_TOKEN_HOST",
+			Value: helpers.GetAPIValues(r.LagoonAPIConfiguration, "LAGOON_CONFIG_TOKEN_HOST"),
+		},
+		{
+			Name:  "LAGOON_CONFIG_TOKEN_PORT",
+			Value: helpers.GetAPIValues(r.LagoonAPIConfiguration, "LAGOON_CONFIG_TOKEN_PORT"),
 		},
 		{
 			Name:  "LAGOON_CONFIG_SSH_HOST",
-			Value: r.LagoonAPIConfiguration.SSHHost,
+			Value: helpers.GetAPIValues(r.LagoonAPIConfiguration, "LAGOON_CONFIG_SSH_HOST"),
 		},
 		{
 			Name:  "LAGOON_CONFIG_SSH_PORT",
-			Value: r.LagoonAPIConfiguration.SSHPort,
+			Value: helpers.GetAPIValues(r.LagoonAPIConfiguration, "LAGOON_CONFIG_SSH_PORT"),
 		},
-		// in the future, the SSH_HOST and SSH_PORT could also have regional variants
 	}
 	// add proxy variables to builds if they are defined
 	if r.ProxyConfig.HTTPProxy != "" {

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	gopkg.in/matryer/try.v1 v1.0.0-20150601225556-312d2599e12e
 	gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5
 	k8s.io/api v0.25.3
+	k8s.io/apiextensions-apiserver v0.25.0
 	k8s.io/apimachinery v0.25.3
 	k8s.io/client-go v0.25.3
 	sigs.k8s.io/controller-runtime v0.13.0
@@ -95,7 +96,6 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.25.0 // indirect
 	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect

--- a/internal/helpers/config_helpers.go
+++ b/internal/helpers/config_helpers.go
@@ -1,0 +1,25 @@
+package helpers
+
+func GetAPIValues(apiConfig LagoonAPIConfiguration, value string) string {
+	switch value {
+	// LAGOON_CONFIG_X are the supported path now
+	case "LAGOON_CONFIG_API_HOST":
+		return apiConfig.APIHost
+	case "LAGOON_CONFIG_TOKEN_HOST":
+		return apiConfig.TokenHost
+	case "LAGOON_CONFIG_TOKEN_PORT":
+		return apiConfig.TokenPort
+	case "LAGOON_CONFIG_SSH_HOST":
+		return apiConfig.SSHHost
+	case "LAGOON_CONFIG_SSH_PORT":
+		return apiConfig.SSHPort
+	// TODO: deprecate TASK_X
+	case "TASK_API_HOST":
+		return apiConfig.APIHost
+	case "TASK_SSH_HOST":
+		return apiConfig.TokenHost
+	case "TASK_SSH_PORT":
+		return apiConfig.TokenPort
+	}
+	return ""
+}

--- a/internal/helpers/helper_types.go
+++ b/internal/helpers/helper_types.go
@@ -22,3 +22,12 @@ type RegistryCredentials struct {
 	Email    string `json:"email"`
 	Auth     string `json:"auth"`
 }
+
+// LagoonAPIConfiguration is for the settings for task API/SSH host/ports
+type LagoonAPIConfiguration struct {
+	APIHost   string
+	TokenHost string
+	TokenPort string
+	SSHHost   string
+	SSHPort   string
+}

--- a/main.go
+++ b/main.go
@@ -62,6 +62,8 @@ var (
 	lagoonAPIHost                   string
 	lagoonSSHHost                   string
 	lagoonSSHPort                   string
+	lagoonTokenHost                 string
+	lagoonTokenPort                 string
 	tlsSkipVerify                   bool
 	advancedTaskSSHKeyInjection     bool
 	advancedTaskDeployToken         bool
@@ -214,6 +216,10 @@ func main() {
 		"The host address for the Lagoon SSH service.")
 	flag.StringVar(&lagoonSSHPort, "lagoon-ssh-port", "2020",
 		"The port for the Lagoon SSH service.")
+	flag.StringVar(&lagoonTokenHost, "lagoon-token-host", "ssh.lagoon.svc",
+		"The host address for the Lagoon Token service.")
+	flag.StringVar(&lagoonTokenPort, "lagoon-token-port", "2020",
+		"The port for the Lagoon Token service.")
 	// @TODO: Nothing uses this at the moment, but could be use in the future by controllers
 	flag.BoolVar(&enableDebug, "enable-debug", false,
 		"Flag to enable more verbose debugging logs.")
@@ -387,9 +393,16 @@ func main() {
 		setupLog.Error(fmt.Errorf("controller-namespace is empty"), "unable to start manager")
 		os.Exit(1)
 	}
+	// LAGOON_CONFIG_X are the supported path now
+	lagoonAPIHost = helpers.GetEnv("LAGOON_CONFIG_API_HOST", lagoonAPIHost)
+	lagoonTokenHost = helpers.GetEnv("LAGOON_CONFIG_TOKEN_HOST", lagoonTokenHost)
+	lagoonTokenPort = helpers.GetEnv("LAGOON_CONFIG_TOKEN_PORT", lagoonTokenPort)
+	lagoonSSHHost = helpers.GetEnv("LAGOON_CONFIG_SSH_HOST", lagoonSSHHost)
+	lagoonSSHPort = helpers.GetEnv("LAGOON_CONFIG_SSH_PORT", lagoonSSHPort)
+	// TODO: deprecate TASK_X variables
 	lagoonAPIHost = helpers.GetEnv("TASK_API_HOST", lagoonAPIHost)
-	lagoonSSHHost = helpers.GetEnv("TASK_SSH_HOST", lagoonSSHHost)
-	lagoonSSHPort = helpers.GetEnv("TASK_SSH_PORT", lagoonSSHPort)
+	lagoonTokenHost = helpers.GetEnv("TASK_SSH_HOST", lagoonTokenHost)
+	lagoonTokenPort = helpers.GetEnv("TASK_SSH_PORT", lagoonTokenPort)
 
 	nativeCronPodMinFrequency = helpers.GetEnvInt("NATIVE_CRON_POD_MINIMUM_FREQUENCY", nativeCronPodMinFrequency)
 
@@ -775,7 +788,7 @@ func main() {
 		NativeCronPodMinFrequency:        nativeCronPodMinFrequency,
 		LagoonTargetName:                 lagoonTargetName,
 		LagoonFeatureFlags:               helpers.GetLagoonFeatureFlags(),
-		LagoonAPIConfiguration: lagoonv1beta1ctrl.LagoonAPIConfiguration{
+		LagoonAPIConfiguration: helpers.LagoonAPIConfiguration{
 			APIHost: lagoonAPIHost,
 			SSHHost: lagoonSSHHost,
 			SSHPort: lagoonSSHPort,
@@ -811,7 +824,7 @@ func main() {
 		ControllerNamespace:   controllerNamespace,
 		NamespacePrefix:       namespacePrefix,
 		RandomNamespacePrefix: randomPrefix,
-		LagoonAPIConfiguration: lagoonv1beta1ctrl.LagoonAPIConfiguration{
+		LagoonAPIConfiguration: helpers.LagoonAPIConfiguration{
 			APIHost: lagoonAPIHost,
 			SSHHost: lagoonSSHHost,
 			SSHPort: lagoonSSHPort,

--- a/main.go
+++ b/main.go
@@ -213,9 +213,9 @@ func main() {
 	flag.StringVar(&lagoonAPIHost, "lagoon-api-host", "http://10.0.2.2:3000",
 		"The host address for the lagoon API.")
 	flag.StringVar(&lagoonSSHHost, "lagoon-ssh-host", "ssh.lagoon.svc",
-		"The host address for the Lagoon SSH service.")
+		"The host address for the Lagoon SSH service, or ssh-portal service.")
 	flag.StringVar(&lagoonSSHPort, "lagoon-ssh-port", "2020",
-		"The port for the Lagoon SSH service.")
+		"The port for the Lagoon SSH service, or ssh-portal service.")
 	flag.StringVar(&lagoonTokenHost, "lagoon-token-host", "ssh.lagoon.svc",
 		"The host address for the Lagoon Token service.")
 	flag.StringVar(&lagoonTokenPort, "lagoon-token-port", "2020",
@@ -789,9 +789,11 @@ func main() {
 		LagoonTargetName:                 lagoonTargetName,
 		LagoonFeatureFlags:               helpers.GetLagoonFeatureFlags(),
 		LagoonAPIConfiguration: helpers.LagoonAPIConfiguration{
-			APIHost: lagoonAPIHost,
-			SSHHost: lagoonSSHHost,
-			SSHPort: lagoonSSHPort,
+			APIHost:   lagoonAPIHost,
+			TokenHost: lagoonTokenHost,
+			TokenPort: lagoonTokenPort,
+			SSHHost:   lagoonSSHHost,
+			SSHPort:   lagoonSSHPort,
 		},
 		ProxyConfig: lagoonv1beta1ctrl.ProxyConfig{
 			HTTPProxy:  httpProxy,
@@ -825,9 +827,11 @@ func main() {
 		NamespacePrefix:       namespacePrefix,
 		RandomNamespacePrefix: randomPrefix,
 		LagoonAPIConfiguration: helpers.LagoonAPIConfiguration{
-			APIHost: lagoonAPIHost,
-			SSHHost: lagoonSSHHost,
-			SSHPort: lagoonSSHPort,
+			APIHost:   lagoonAPIHost,
+			TokenHost: lagoonTokenHost,
+			TokenPort: lagoonTokenPort,
+			SSHHost:   lagoonSSHHost,
+			SSHPort:   lagoonSSHPort,
 		},
 		EnableDebug:      enableDebug,
 		LagoonTargetName: lagoonTargetName,


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

#146 introduced `LAGOON_CONFIG_X` variables to be injected into tasks and builds. so far these have not been used by the `build-deploy-tool`, but https://github.com/uselagoon/build-deploy-tool/pull/193 plans to introduce these in the future (that PR will be updated to reflect these changes).

This PR is changing `TASK_SSH_HOST/PORT` to now be the token service address, and introduces `LAGOON_CONFIG_TOKEN_HOST/PORT`. These will be used by [tasks resolvers](https://github.com/uselagoon/lagoon/blob/749a3f6a8290d318b71f3f824b189ed8c03cc93d/services/api/src/resources/task/resolvers.ts#L438) soon too.

`LAGOON_CONFIG_SSH_HOST/PORT` has been changed to now be the regional ssh portal address definition. In a lagoon-remote installation via helmchart, this can be defined as the internal service name and port because all communications within the cluster would be internally anyway.

The `TASK_X` variables are deprecated, and should avoid being used from now on, and instead use the `LAGOON_CONFIG_X` variables where required.

# Closes
closes #199