### PR TITLE
chore: make sure builds use the build resource uid

### DIFF
--- a/controllers/v1beta1/podmonitor_buildhandlers.go
+++ b/controllers/v1beta1/podmonitor_buildhandlers.go
@@ -153,6 +153,10 @@ func (r *LagoonMonitorReconciler) buildLogsToLagoonLogs(ctx context.Context,
 			pID, _ := strconv.Atoi(namespace.ObjectMeta.Labels["lagoon.sh/environment"])
 			projectID = helpers.UintPtr(uint(pID))
 		}
+		remoteId := string(jobPod.ObjectMeta.UID)
+		if value, ok := jobPod.Labels["lagoon.sh/buildRemoteID"]; ok {
+			remoteId = value
+		}
 		msg := lagoonv1beta1.LagoonLog{
 			Severity: "info",
 			Project:  projectName,
@@ -165,7 +169,7 @@ func (r *LagoonMonitorReconciler) buildLogsToLagoonLogs(ctx context.Context,
 				BuildPhase:    condition, // @TODO: same as buildstatus label, remove once lagoon is corrected in controller-handler
 				BuildStatus:   condition, // same as buildstatus label
 				BuildStep:     buildStep,
-				RemoteID:      string(jobPod.ObjectMeta.UID),
+				RemoteID:      remoteId,
 				LogLink:       lagoonBuild.Spec.Project.UILink,
 				Cluster:       r.LagoonTargetName,
 			},
@@ -230,6 +234,7 @@ func (r *LagoonMonitorReconciler) updateDeploymentAndEnvironmentTask(ctx context
 					"build_name":      lagoonBuild.ObjectMeta.Name,
 				})
 			})
+			time.Sleep(2 * time.Second) // smol sleep to reduce race of final messages with previous messages
 		}
 		envName := lagoonBuild.Spec.Project.Environment
 		envID := lagoonBuild.Spec.Project.EnvironmentID
@@ -242,6 +247,10 @@ func (r *LagoonMonitorReconciler) updateDeploymentAndEnvironmentTask(ctx context
 			projectName = namespace.ObjectMeta.Labels["lagoon.sh/environment"]
 			pID, _ := strconv.Atoi(namespace.ObjectMeta.Labels["lagoon.sh/environment"])
 			projectID = helpers.UintPtr(uint(pID))
+		}
+		remoteId := string(jobPod.ObjectMeta.UID)
+		if value, ok := jobPod.Labels["lagoon.sh/buildRemoteID"]; ok {
+			remoteId = value
 		}
 		msg := lagoonv1beta1.LagoonMessage{
 			Type:      "build",
@@ -256,7 +265,7 @@ func (r *LagoonMonitorReconciler) updateDeploymentAndEnvironmentTask(ctx context
 				BuildStatus:   condition, // same as buildstatus label
 				BuildStep:     buildStep,
 				LogLink:       lagoonBuild.Spec.Project.UILink,
-				RemoteID:      string(jobPod.ObjectMeta.UID),
+				RemoteID:      remoteId,
 				Cluster:       r.LagoonTargetName,
 			},
 		}


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Currently builds will switch between using the build resource uuid and the build pod uuid as the `remoteId` that lagoon uses to display logs, but not on purpose. This can cause some logs to be lost when recalled as the remoteId changes during a build from one to another.

This PR fixes it by ensuring that all logs use the uuid of the build resource.