### PR TITLE
chore: small sleep to delay final message

### DIFF
--- a/controllers/v1beta1/podmonitor_taskhandlers.go
+++ b/controllers/v1beta1/podmonitor_taskhandlers.go
@@ -161,6 +161,7 @@ func (r *LagoonMonitorReconciler) updateLagoonTask(ctx context.Context, opLog lo
 					"task_name":      lagoonTask.ObjectMeta.Name,
 				})
 			})
+			time.Sleep(2 * time.Second) // smol sleep to reduce race of final messages with previous messages
 		}
 		msg := lagoonv1beta1.LagoonMessage{
 			Type:      "task",


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

To try and reduce race conditions of the last pod status change and the final completion message for a task, introduce a small sleep delay.