### PR TITLE
chore: make sure we pass the right values back to core when cancelling a task

### DIFF
--- a/internal/messenger/tasks_handler.go
+++ b/internal/messenger/tasks_handler.go
@@ -215,6 +215,12 @@ func (m *Messenger) updateLagoonTask(opLog logr.Logger, namespace string, jobSpe
 			Project:     jobSpec.Project.Name,
 			JobName:     taskName,
 			JobStatus:   "cancelled",
+			Task: &lagoonv1beta1.LagoonTaskInfo{
+				TaskName: jobSpec.Task.TaskName,
+				ID:       jobSpec.Task.ID,
+				Name:     jobSpec.Task.Name,
+				Service:  jobSpec.Task.Service,
+			},
 		},
 	}
 	// if the task isn't found at all, then set the start/end time to be now


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

When cancelling a task that no longer exists in the cluster, we need to pass back some values in the response so the actions-handler knows how to cancel the task properly.

Part of https://github.com/uselagoon/lagoon/pull/3112 but can be merged and released prior to the core pullrequest