### PR TITLE
refactor: use injection from the task data from the lagoon api

### DIFF
--- a/apis/lagoon/v1beta1/lagoontask_types.go
+++ b/apis/lagoon/v1beta1/lagoontask_types.go
@@ -81,14 +81,16 @@ type LagoonTaskSpec struct {
 
 // LagoonTaskInfo defines what a task can use to communicate with Lagoon via SSH/API.
 type LagoonTaskInfo struct {
-	ID       string `json:"id"` // should be int, but the api sends it as a string :\
-	Name     string `json:"name,omitempty"`
-	TaskName string `json:"taskName,omitempty"`
-	Service  string `json:"service,omitempty"`
-	Command  string `json:"command,omitempty"`
-	SSHHost  string `json:"sshHost,omitempty"`
-	SSHPort  string `json:"sshPort,omitempty"`
-	APIHost  string `json:"apiHost,omitempty"`
+	ID                   string `json:"id"` // should be int, but the api sends it as a string :\
+	Name                 string `json:"name,omitempty"`
+	TaskName             string `json:"taskName,omitempty"`
+	Service              string `json:"service,omitempty"`
+	Command              string `json:"command,omitempty"`
+	SSHHost              string `json:"sshHost,omitempty"`
+	SSHPort              string `json:"sshPort,omitempty"`
+	APIHost              string `json:"apiHost,omitempty"`
+	DeployTokenInjection bool   `json:"deployTokenInjection,omitempty"`
+	ProjectKeyInjection  bool   `json:"projectKeyInjection,omitempty"`
 }
 
 // LagoonAdvancedTaskInfo defines what an advanced task can use for the creation of the pod.

--- a/config/crd/bases/crd.lagoon.sh_lagoonbuilds.yaml
+++ b/config/crd/bases/crd.lagoon.sh_lagoonbuilds.yaml
@@ -268,10 +268,14 @@ spec:
                             type: string
                           command:
                             type: string
+                          deployTokenInjection:
+                            type: boolean
                           id:
                             type: string
                           name:
                             type: string
+                          projectKeyInjection:
+                            type: boolean
                           service:
                             type: string
                           sshHost:
@@ -357,10 +361,14 @@ spec:
                             type: string
                           command:
                             type: string
+                          deployTokenInjection:
+                            type: boolean
                           id:
                             type: string
                           name:
                             type: string
+                          projectKeyInjection:
+                            type: boolean
                           service:
                             type: string
                           sshHost:
@@ -448,10 +456,14 @@ spec:
                             type: string
                           command:
                             type: string
+                          deployTokenInjection:
+                            type: boolean
                           id:
                             type: string
                           name:
                             type: string
+                          projectKeyInjection:
+                            type: boolean
                           service:
                             type: string
                           sshHost:
@@ -541,10 +553,14 @@ spec:
                             type: string
                           command:
                             type: string
+                          deployTokenInjection:
+                            type: boolean
                           id:
                             type: string
                           name:
                             type: string
+                          projectKeyInjection:
+                            type: boolean
                           service:
                             type: string
                           sshHost:

--- a/config/crd/bases/crd.lagoon.sh_lagoontasks.yaml
+++ b/config/crd/bases/crd.lagoon.sh_lagoontasks.yaml
@@ -132,10 +132,14 @@ spec:
                     type: string
                   command:
                     type: string
+                  deployTokenInjection:
+                    type: boolean
                   id:
                     type: string
                   name:
                     type: string
+                  projectKeyInjection:
+                    type: boolean
                   service:
                     type: string
                   sshHost:
@@ -250,10 +254,14 @@ spec:
                             type: string
                           command:
                             type: string
+                          deployTokenInjection:
+                            type: boolean
                           id:
                             type: string
                           name:
                             type: string
+                          projectKeyInjection:
+                            type: boolean
                           service:
                             type: string
                           sshHost:
@@ -339,10 +347,14 @@ spec:
                             type: string
                           command:
                             type: string
+                          deployTokenInjection:
+                            type: boolean
                           id:
                             type: string
                           name:
                             type: string
+                          projectKeyInjection:
+                            type: boolean
                           service:
                             type: string
                           sshHost:
@@ -430,10 +442,14 @@ spec:
                             type: string
                           command:
                             type: string
+                          deployTokenInjection:
+                            type: boolean
                           id:
                             type: string
                           name:
                             type: string
+                          projectKeyInjection:
+                            type: boolean
                           service:
                             type: string
                           sshHost:
@@ -523,10 +539,14 @@ spec:
                             type: string
                           command:
                             type: string
+                          deployTokenInjection:
+                            type: boolean
                           id:
                             type: string
                           name:
                             type: string
+                          projectKeyInjection:
+                            type: boolean
                           service:
                             type: string
                           sshHost:

--- a/internal/messenger/tasks_handler.go
+++ b/internal/messenger/tasks_handler.go
@@ -264,11 +264,11 @@ func (m *Messenger) ActiveStandbySwitch(namespace string, jobSpec *lagoonv1beta1
 
 // AdvancedTask handles running the ingress migrations.
 func (m *Messenger) AdvancedTask(namespace string, jobSpec *lagoonv1beta1.LagoonTaskSpec) error {
-	if m.AdvancedTaskSSHKeyInjection {
-		jobSpec.AdvancedTask.SSHKey = true
+	if jobSpec.Task.DeployTokenInjection {
+		jobSpec.AdvancedTask.DeployerToken = jobSpec.Task.DeployTokenInjection
 	}
-	if m.AdvancedTaskDeployTokenInjection {
-		jobSpec.AdvancedTask.DeployerToken = true
+	if jobSpec.Task.ProjectKeyInjection {
+		jobSpec.AdvancedTask.SSHKey = jobSpec.Task.ProjectKeyInjection
 	}
 	return m.createAdvancedTask(namespace, jobSpec, nil)
 }

--- a/main.go
+++ b/main.go
@@ -284,10 +284,11 @@ func main() {
 	flag.BoolVar(&tlsSkipVerify, "skip-tls-verify", false, "Flag to skip tls verification for http clients (harbor).")
 
 	// default the sshkey injection to true for now, eventually Lagoon should handle this for tasks that require it
+	// these are deprecated now and do nothing as the values are sourced from the lagoon task now
 	flag.BoolVar(&advancedTaskSSHKeyInjection, "advanced-task-sshkey-injection", true,
-		"Flag to specify injecting the sshkey for the environment into any advanced tasks.")
+		"DEPRECATED: Flag to specify injecting the sshkey for the environment into any advanced tasks.")
 	flag.BoolVar(&advancedTaskDeployToken, "advanced-task-deploytoken-injection", false,
-		"Flag to specify injecting the deploy token for the environment into any advanced tasks.")
+		"DEPRECATED: Flag to specify injecting the deploy token for the environment into any advanced tasks.")
 
 	flag.BoolVar(&cleanupHarborRepositoryOnDelete, "cleanup-harbor-repository-on-delete", false,
 		"Flag to specify if when deleting an environment, the associated harbor repository/images should be removed too.")


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Deprecates the older injection flags that were added for support before the Lagoon API had proper support for providing these values. Now that the API has provided these for some time, we should use these instead.
