### PR TITLE
refactor: send better buildstep messages for queued and failed builds

### DIFF
--- a/controllers/v1beta1/build_deletionhandlers.go
+++ b/controllers/v1beta1/build_deletionhandlers.go
@@ -213,7 +213,7 @@ Build cancelled
 		}
 		// send any messages to lagoon message queues
 		// update the deployment with the status of cancelled in lagoon
-		r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &lagoonEnv, lagoonv1beta1.BuildStatusCancelled)
+		r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &lagoonEnv, lagoonv1beta1.BuildStatusCancelled, "cancelled")
 		r.updateDeploymentAndEnvironmentTask(ctx, opLog, &lagoonBuild, &lagoonEnv, lagoonv1beta1.BuildStatusCancelled)
 		r.buildLogsToLagoonLogs(ctx, opLog, &lagoonBuild, allContainerLogs, lagoonv1beta1.BuildStatusCancelled)
 	}
@@ -367,6 +367,7 @@ func (r *LagoonBuildReconciler) buildStatusLogsToLagoonLogs(ctx context.Context,
 	lagoonBuild *lagoonv1beta1.LagoonBuild,
 	lagoonEnv *corev1.ConfigMap,
 	buildCondition lagoonv1beta1.BuildStatusType,
+	buildStep string,
 ) {
 	if r.EnableMQ {
 		msg := lagoonv1beta1.LagoonLog{
@@ -378,6 +379,7 @@ func (r *LagoonBuildReconciler) buildStatusLogsToLagoonLogs(ctx context.Context,
 				BranchName:  lagoonBuild.Spec.Project.Environment,
 				BuildPhase:  buildCondition.ToLower(),
 				BuildName:   lagoonBuild.ObjectMeta.Name,
+				BuildStep:   buildStep,
 				LogLink:     lagoonBuild.Spec.Project.UILink,
 				Cluster:     r.LagoonTargetName,
 			},

--- a/controllers/v1beta1/build_helpers.go
+++ b/controllers/v1beta1/build_helpers.go
@@ -868,11 +868,11 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 func (r *LagoonBuildReconciler) updateQueuedBuild(
 	ctx context.Context,
 	lagoonBuild lagoonv1beta1.LagoonBuild,
-	message string,
+	queuePosition, queueLength int,
 	opLog logr.Logger,
 ) error {
 	if r.EnableDebug {
-		opLog.Info(fmt.Sprintf("Updating build %s to queued: %s", lagoonBuild.ObjectMeta.Name, message))
+		opLog.Info(fmt.Sprintf("Updating build %s to queued: %s", lagoonBuild.ObjectMeta.Name, fmt.Sprintf("This build is currently queued in position %v/%v", queuePosition, queueLength)))
 	}
 	var allContainerLogs []byte
 	// if we get this handler, then it is likely that the build was in a pending or running state with no actual running pod
@@ -881,7 +881,7 @@ func (r *LagoonBuildReconciler) updateQueuedBuild(
 ========================================
 %s
 ========================================
-`, message))
+`, fmt.Sprintf("This build is currently queued in position %v/%v", queuePosition, queueLength)))
 	// get the configmap for lagoon-env so we can use it for updating the deployment in lagoon
 	var lagoonEnv corev1.ConfigMap
 	err := r.Get(ctx, types.NamespacedName{
@@ -900,11 +900,11 @@ func (r *LagoonBuildReconciler) updateQueuedBuild(
 	// send any messages to lagoon message queues
 	// update the deployment with the status, lagoon v2.12.0 supports queued status, otherwise use pending
 	if helpers.CheckLagoonVersion(&lagoonBuild, "2.12.0") {
-		r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &lagoonEnv, lagoonv1beta1.BuildStatusQueued)
+		r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &lagoonEnv, lagoonv1beta1.BuildStatusQueued, fmt.Sprintf("queued %v/%v", queuePosition, queueLength))
 		r.updateDeploymentAndEnvironmentTask(ctx, opLog, &lagoonBuild, &lagoonEnv, lagoonv1beta1.BuildStatusQueued)
 		r.buildLogsToLagoonLogs(ctx, opLog, &lagoonBuild, allContainerLogs, lagoonv1beta1.BuildStatusQueued)
 	} else {
-		r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &lagoonEnv, lagoonv1beta1.BuildStatusPending)
+		r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &lagoonEnv, lagoonv1beta1.BuildStatusPending, fmt.Sprintf("queued %v/%v", queuePosition, queueLength))
 		r.updateDeploymentAndEnvironmentTask(ctx, opLog, &lagoonBuild, &lagoonEnv, lagoonv1beta1.BuildStatusPending)
 		r.buildLogsToLagoonLogs(ctx, opLog, &lagoonBuild, allContainerLogs, lagoonv1beta1.BuildStatusPending)
 
@@ -960,7 +960,7 @@ Build cancelled
 	}
 	// send any messages to lagoon message queues
 	// update the deployment with the status of cancelled in lagoon
-	r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &lagoonEnv, lagoonv1beta1.BuildStatusCancelled)
+	r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &lagoonEnv, lagoonv1beta1.BuildStatusCancelled, "cancelled")
 	r.updateDeploymentAndEnvironmentTask(ctx, opLog, &lagoonBuild, &lagoonEnv, lagoonv1beta1.BuildStatusCancelled)
 	if cancelled {
 		r.buildLogsToLagoonLogs(ctx, opLog, &lagoonBuild, allContainerLogs, lagoonv1beta1.BuildStatusCancelled)

--- a/controllers/v1beta1/build_qoshandler.go
+++ b/controllers/v1beta1/build_qoshandler.go
@@ -143,7 +143,7 @@ func (r *LagoonBuildReconciler) whichBuildNext(ctx context.Context, opLog logr.L
 				// update the build to be queued, and add a log message with the build log with the current position in the queue
 				// this position will update as builds are created/processed, so the position of a build could change depending on
 				// higher or lower priority builds being created
-				r.updateQueuedBuild(ctx, pBuild, fmt.Sprintf("This build is currently queued in position %v/%v", (idx+1), len(pendingBuilds.Items)), opLog)
+				r.updateQueuedBuild(ctx, pBuild, (idx + 1), len(pendingBuilds.Items), opLog)
 			}
 		}
 	}

--- a/controllers/v1beta1/podmonitor_buildhandlers.go
+++ b/controllers/v1beta1/podmonitor_buildhandlers.go
@@ -138,6 +138,11 @@ func (r *LagoonMonitorReconciler) buildLogsToLagoonLogs(ctx context.Context,
 ) (bool, lagoonv1beta1.LagoonLog) {
 	if r.EnableMQ {
 		buildStep := "running"
+		if condition == "failed" || condition == "complete" || condition == "cancelled" {
+			// set build step to anything other than running if the condition isn't running
+			buildStep = condition
+		}
+		// then check the resource to see if the buildstep exists, this bit we care about so we can see where it maybe failed if its available
 		if value, ok := jobPod.Labels["lagoon.sh/buildStep"]; ok {
 			buildStep = value
 		}
@@ -224,6 +229,11 @@ func (r *LagoonMonitorReconciler) updateDeploymentAndEnvironmentTask(ctx context
 ) (bool, lagoonv1beta1.LagoonMessage) {
 	if r.EnableMQ {
 		buildStep := "running"
+		if condition == "failed" || condition == "complete" || condition == "cancelled" {
+			// set build step to anything other than running if the condition isn't running
+			buildStep = condition
+		}
+		// then check the resource to see if the buildstep exists, this bit we care about so we can see where it maybe failed if its available
 		if value, ok := jobPod.Labels["lagoon.sh/buildStep"]; ok {
 			buildStep = value
 		}
@@ -355,6 +365,11 @@ func (r *LagoonMonitorReconciler) buildStatusLogsToLagoonLogs(ctx context.Contex
 ) (bool, lagoonv1beta1.LagoonLog) {
 	if r.EnableMQ {
 		buildStep := "running"
+		if condition == "failed" || condition == "complete" || condition == "cancelled" {
+			// set build step to anything other than running if the condition isn't running
+			buildStep = condition
+		}
+		// then check the resource to see if the buildstep exists, this bit we care about so we can see where it maybe failed if its available
 		if value, ok := jobPod.Labels["lagoon.sh/buildStep"]; ok {
 			buildStep = value
 		}


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

This adds a `queued 1/1` build step to queued builds, but also corrects a problem with builds that fail but the buildstep still shows as `running` which would be confusing
```
        {
          "name": "lagoon-build-nhl0y",
          "status": "failed",
          "buildStep": "running"
        },
```
