### PR TITLE
refactor: allow overriding harbor cleanups by labelling secret

### DIFF
--- a/internal/harbor/harbor22x.go
+++ b/internal/harbor/harbor22x.go
@@ -125,7 +125,6 @@ func (h *Harbor) CreateOrRefreshRobotV2(ctx context.Context,
 	expiry time.Duration,
 	force bool,
 ) (*helpers.RegistryCredentials, error) {
-
 	// create a cluster specific robot account name
 	robotName := h.generateRobotName(environmentName)
 
@@ -270,7 +269,7 @@ func (h *Harbor) DeleteRepository(ctx context.Context, projectName, branch strin
 	environmentName := helpers.ShortenEnvironment(projectName, helpers.MakeSafe(branch))
 	h.Config.PageSize = 100
 	pageCount := int64(1)
-	listRepositories := h.ListRepositories(ctx, projectName, pageCount)
+	listRepositories := h.ListRepositories(ctx, projectName)
 	for _, repo := range listRepositories {
 		if strings.Contains(repo.Name, fmt.Sprintf("%s/%s", projectName, environmentName)) {
 			repoName := strings.Replace(repo.Name, fmt.Sprintf("%s/", projectName), "", 1)
@@ -285,7 +284,7 @@ func (h *Harbor) DeleteRepository(ctx context.Context, projectName, branch strin
 		pageCount = int64(len(listRepositories) / 100)
 		var page int64
 		for page = 2; page <= pageCount; page++ {
-			listRepositories := h.ListRepositories(ctx, projectName, page)
+			listRepositories := h.ListRepositories(ctx, projectName)
 			for _, repo := range listRepositories {
 				if strings.Contains(repo.Name, fmt.Sprintf("%s/%s", projectName, environmentName)) {
 					repoName := strings.Replace(repo.Name, fmt.Sprintf("%s/", projectName), "", 1)
@@ -299,8 +298,34 @@ func (h *Harbor) DeleteRepository(ctx context.Context, projectName, branch strin
 	}
 }
 
+// DeleteRobotAccount will delete robot account related to an environment
+func (h *Harbor) DeleteRobotAccount(ctx context.Context, projectName, branch string) {
+	environmentName := helpers.ShortenEnvironment(projectName, helpers.MakeSafe(branch))
+	robots, err := h.ClientV5.ListProjectRobotsV1(
+		ctx,
+		projectName,
+	)
+	if err != nil {
+		h.Log.Info(fmt.Sprintf("Error listing project %s robot accounts", projectName))
+		return
+	}
+	for _, robot := range robots {
+		if h.matchRobotAccountV2(robot.Name, projectName, environmentName) {
+			err := h.ClientV5.DeleteProjectRobotV1(
+				ctx,
+				projectName,
+				int64(robot.ID),
+			)
+			if err != nil {
+				h.Log.Info(fmt.Sprintf("Error deleting project %s robot account %s", projectName, robot.Name))
+				return
+			}
+		}
+	}
+}
+
 // ListRepositories .
-func (h *Harbor) ListRepositories(ctx context.Context, projectName string, pageNumber int64) []*harborclientv5model.Repository {
+func (h *Harbor) ListRepositories(ctx context.Context, projectName string) []*harborclientv5model.Repository {
 	listRepositories, err := h.ClientV5.ListRepositories(ctx, projectName)
 	if err != nil {
 		h.Log.Info(fmt.Sprintf("Error listing harbor repositories for project %s", projectName))

--- a/internal/utilities/deletions/deletions.go
+++ b/internal/utilities/deletions/deletions.go
@@ -6,8 +6,6 @@ import (
 	"github.com/uselagoon/remote-controller/internal/harbor"
 )
 
-const HarborCleanup = "lagoon.sh/cleanup-harbor"
-
 type DeleteConfig struct {
 	PVCRetryAttempts int `json:"pvcRetryAttempts"`
 	PVCRetryInterval int `json:"pvcRetryInterval"`


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

When migrating environments between clusters, if harbor cleanup is enabled, when the source environment is deleted, it will delete the images that the destination environment uses.

This adds labels that can be added to the source environment `lagoon-internal-registry-secret` secret, that will make sure that the remote-controller won't remove the images from harbor when the environment is eventually pruned.

# Closing issues

closes #60 