### PR TITLE
fix: set the default page to be 1 so that pagination works properly

### DIFF
--- a/internal/harbor/harbor.go
+++ b/internal/harbor/harbor.go
@@ -46,6 +46,7 @@ func New(harbor Harbor) (*Harbor, error) {
 	}
 	harbor.ClientV3 = c
 	harbor.Config = &config.Options{
+		Page:     1,
 		PageSize: 100,
 	}
 	c2, err := harborclientv5.NewRESTClientForHost(harbor.API, harbor.Username, harbor.Password, harbor.Config)

--- a/internal/harbor/harbor22x.go
+++ b/internal/harbor/harbor22x.go
@@ -190,6 +190,7 @@ func (h *Harbor) CreateOrRefreshRobotV2(ctx context.Context,
 	robots = tempRobots
 	for _, robot := range robots {
 		if h.matchRobotAccountV2(robot.Name, project.Name, environmentName) && robot.Editable {
+			h.Log.Info(fmt.Sprintf("Harbor robot account %s matched", robot.Name))
 			// if it is a new robot account, follow through here
 			exists = true
 			if forceRecreate || force {


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

The harbor client library used doesn't set a default page number to start with so assumes 0. This results in the library not properly iterating over the pages and not returning all the robot accounts. This corrects the bug by setting the default page number to be 1
