### PR TITLE
refactor: split queue process out

### DIFF
--- a/controllers/v1beta1/build_helpers_test.go
+++ b/controllers/v1beta1/build_helpers_test.go
@@ -1,0 +1,233 @@
+package v1beta1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	lagoonv1beta1 "github.com/uselagoon/remote-controller/apis/lagoon/v1beta1"
+	"github.com/uselagoon/remote-controller/internal/helpers"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func timeFromString(s string) time.Time {
+	time, _ := time.Parse("2006-01-02T15:04:05.000Z", s)
+	return time
+}
+
+func Test_sortBuilds(t *testing.T) {
+	type args struct {
+		defaultPriority int
+		pendingBuilds   *lagoonv1beta1.LagoonBuildList
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantBuilds *lagoonv1beta1.LagoonBuildList
+	}{
+		{
+			name: "test1 - 5 and 6 same time order by priority",
+			args: args{
+				defaultPriority: 5,
+				pendingBuilds: &lagoonv1beta1.LagoonBuildList{
+					Items: []lagoonv1beta1.LagoonBuild{
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Name:              "lagoon-build-abcdefg",
+								CreationTimestamp: v1.NewTime(timeFromString("2023-09-18T11:45:00.000Z")),
+							},
+							Spec: lagoonv1beta1.LagoonBuildSpec{
+								Build: lagoonv1beta1.Build{
+									Priority: helpers.IntPtr(5),
+								},
+							},
+						},
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Name:              "lagoon-build-1234567",
+								CreationTimestamp: v1.NewTime(timeFromString("2023-09-18T11:45:00.000Z")),
+							},
+							Spec: lagoonv1beta1.LagoonBuildSpec{
+								Build: lagoonv1beta1.Build{
+									Priority: helpers.IntPtr(6),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantBuilds: &lagoonv1beta1.LagoonBuildList{
+				Items: []lagoonv1beta1.LagoonBuild{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name:              "lagoon-build-abcdefg",
+							CreationTimestamp: v1.NewTime(timeFromString("2023-09-18T11:45:00.000Z")),
+						},
+						Spec: lagoonv1beta1.LagoonBuildSpec{
+							Build: lagoonv1beta1.Build{
+								Priority: helpers.IntPtr(5),
+							},
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name:              "lagoon-build-1234567",
+							CreationTimestamp: v1.NewTime(timeFromString("2023-09-18T11:45:00.000Z")),
+						},
+						Spec: lagoonv1beta1.LagoonBuildSpec{
+							Build: lagoonv1beta1.Build{
+								Priority: helpers.IntPtr(6),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "test2 - 2x5 sorted by time",
+			args: args{
+				defaultPriority: 5,
+				pendingBuilds: &lagoonv1beta1.LagoonBuildList{
+					Items: []lagoonv1beta1.LagoonBuild{
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Name:              "lagoon-build-abcdefg",
+								CreationTimestamp: v1.NewTime(timeFromString("2023-09-18T11:50:00.000Z")),
+							},
+							Spec: lagoonv1beta1.LagoonBuildSpec{
+								Build: lagoonv1beta1.Build{
+									Priority: helpers.IntPtr(5),
+								},
+							},
+						},
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Name:              "lagoon-build-1234567",
+								CreationTimestamp: v1.NewTime(timeFromString("2023-09-18T11:45:00.000Z")),
+							},
+							Spec: lagoonv1beta1.LagoonBuildSpec{
+								Build: lagoonv1beta1.Build{
+									Priority: helpers.IntPtr(5),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantBuilds: &lagoonv1beta1.LagoonBuildList{
+				Items: []lagoonv1beta1.LagoonBuild{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name:              "lagoon-build-1234567",
+							CreationTimestamp: v1.NewTime(timeFromString("2023-09-18T11:45:00.000Z")),
+						},
+						Spec: lagoonv1beta1.LagoonBuildSpec{
+							Build: lagoonv1beta1.Build{
+								Priority: helpers.IntPtr(5),
+							},
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name:              "lagoon-build-abcdefg",
+							CreationTimestamp: v1.NewTime(timeFromString("2023-09-18T11:50:00.000Z")),
+						},
+						Spec: lagoonv1beta1.LagoonBuildSpec{
+							Build: lagoonv1beta1.Build{
+								Priority: helpers.IntPtr(5),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "test3 - 2x5 and 1x6 sorted by priority then time",
+			args: args{
+				defaultPriority: 5,
+				pendingBuilds: &lagoonv1beta1.LagoonBuildList{
+					Items: []lagoonv1beta1.LagoonBuild{
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Name:              "lagoon-build-abcdefg",
+								CreationTimestamp: v1.NewTime(timeFromString("2023-09-18T11:50:00.000Z")),
+							},
+							Spec: lagoonv1beta1.LagoonBuildSpec{
+								Build: lagoonv1beta1.Build{
+									Priority: helpers.IntPtr(5),
+								},
+							},
+						},
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Name:              "lagoon-build-abc1234",
+								CreationTimestamp: v1.NewTime(timeFromString("2023-09-18T11:46:00.000Z")),
+							},
+							Spec: lagoonv1beta1.LagoonBuildSpec{
+								Build: lagoonv1beta1.Build{
+									Priority: helpers.IntPtr(6),
+								},
+							},
+						},
+						{
+							ObjectMeta: v1.ObjectMeta{
+								Name:              "lagoon-build-1234567",
+								CreationTimestamp: v1.NewTime(timeFromString("2023-09-18T11:45:00.000Z")),
+							},
+							Spec: lagoonv1beta1.LagoonBuildSpec{
+								Build: lagoonv1beta1.Build{
+									Priority: helpers.IntPtr(5),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantBuilds: &lagoonv1beta1.LagoonBuildList{
+				Items: []lagoonv1beta1.LagoonBuild{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name:              "lagoon-build-1234567",
+							CreationTimestamp: v1.NewTime(timeFromString("2023-09-18T11:45:00.000Z")),
+						},
+						Spec: lagoonv1beta1.LagoonBuildSpec{
+							Build: lagoonv1beta1.Build{
+								Priority: helpers.IntPtr(5),
+							},
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name:              "lagoon-build-abcdefg",
+							CreationTimestamp: v1.NewTime(timeFromString("2023-09-18T11:50:00.000Z")),
+						},
+						Spec: lagoonv1beta1.LagoonBuildSpec{
+							Build: lagoonv1beta1.Build{
+								Priority: helpers.IntPtr(5),
+							},
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name:              "lagoon-build-abc1234",
+							CreationTimestamp: v1.NewTime(timeFromString("2023-09-18T11:46:00.000Z")),
+						},
+						Spec: lagoonv1beta1.LagoonBuildSpec{
+							Build: lagoonv1beta1.Build{
+								Priority: helpers.IntPtr(6),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sortBuilds(tt.args.defaultPriority, tt.args.pendingBuilds)
+			if !cmp.Equal(tt.args.pendingBuilds, tt.wantBuilds) {
+				t.Errorf("sortBuilds() = %v, want %v", tt.args.pendingBuilds, tt.wantBuilds)
+			}
+		})
+	}
+}

--- a/controllers/v1beta1/build_qoshandler.go
+++ b/controllers/v1beta1/build_qoshandler.go
@@ -71,6 +71,10 @@ func (r *LagoonBuildReconciler) whichBuildNext(ctx context.Context, opLog logr.L
 
 var runningProcessQueue bool
 
+// this is a processor for any builds that are currently `queued` status. all normal build activity will still be performed
+// this just allows the controller to update any builds that are in the queue periodically
+// if this ran on every single event, it would flood the queue with messages, so it is restricted using `runningProcessQueue` global
+// to only run the process at any one time til it is complete
 func (r *LagoonBuildReconciler) processQueue(ctx context.Context, opLog logr.Logger, buildsToStart int, limitHit bool) error {
 	// this should only ever be able to run one instance of at a time within a single controller
 	// this is because this process is quite heavy when it goes to submit the queue messages to the api

--- a/controllers/v1beta1/task_controller.go
+++ b/controllers/v1beta1/task_controller.go
@@ -386,7 +386,7 @@ func (r *LagoonTaskReconciler) createAdvancedTask(ctx context.Context, lagoonTas
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName:  "lagoon-sshkey",
-				DefaultMode: helpers.IntPtr(420),
+				DefaultMode: helpers.Int32Ptr(420),
 			},
 		},
 	}
@@ -423,7 +423,7 @@ func (r *LagoonTaskReconciler) createAdvancedTask(ctx context.Context, lagoonTas
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
 						SecretName:  serviceaccountTokenSecret,
-						DefaultMode: helpers.IntPtr(420),
+						DefaultMode: helpers.Int32Ptr(420),
 					},
 				},
 			})
@@ -587,7 +587,7 @@ func (r *LagoonTaskReconciler) createAdvancedTask(ctx context.Context, lagoonTas
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
 						SecretName:  secret.Name,
-						DefaultMode: helpers.IntPtr(444),
+						DefaultMode: helpers.Int32Ptr(444),
 					},
 				},
 			}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cheshir/go-mq/v2 v2.0.1
 	github.com/coreos/go-semver v0.3.1
 	github.com/go-logr/logr v1.2.4
+	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-version v1.6.0
 	github.com/k8up-io/k8up/v2 v2.7.1
 	github.com/mittwald/goharbor-client/v3 v3.3.0
@@ -51,7 +52,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -105,7 +105,15 @@ func TaskContainsStatus(slice []lagoonv1beta1.LagoonTaskConditions, s lagoonv1be
 }
 
 // IntPtr .
-func IntPtr(i int32) *int32 {
+func IntPtr(i int) *int {
+	var iPtr *int
+	iPtr = new(int)
+	*iPtr = i
+	return iPtr
+}
+
+// Int32Ptr .
+func Int32Ptr(i int32) *int32 {
 	var iPtr *int32
 	iPtr = new(int32)
 	*iPtr = i

--- a/main.go
+++ b/main.go
@@ -810,6 +810,8 @@ func main() {
 		RandomNamespacePrefix: randomPrefix,
 		EnableDebug:           enableDebug,
 		LagoonTargetName:      lagoonTargetName,
+		LFFQoSEnabled:         lffQoSEnabled,
+		BuildQoS:              buildQoSConfig,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LagoonMonitor")
 		os.Exit(1)


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Refactoring build queue process to reduce the amount of times that events trigger actions when QoS is enabled.

There were points in the event cycle where when a build completes, it would pick an item from the queue, but if there was also a pending build in the namespace that triggered the event, it would start a build in that namespace too. This allowed clusters to exceed the QoS limit.

This also introduces some additional changes to the way the queue is handled with the sorting function working as it should now by sorting by priority and creation time, and also allows events to trigger period updates of the pending items in a blocking operation