### PR TITLE
fix: revert and fix the deployertoken injection using a custom unmarshal

### DIFF
--- a/config/crd/bases/crd.lagoon.sh_lagoonbuilds.yaml
+++ b/config/crd/bases/crd.lagoon.sh_lagoonbuilds.yaml
@@ -268,14 +268,10 @@ spec:
                             type: string
                           command:
                             type: string
-                          deployTokenInjection:
-                            type: boolean
                           id:
                             type: string
                           name:
                             type: string
-                          projectKeyInjection:
-                            type: boolean
                           service:
                             type: string
                           sshHost:
@@ -361,14 +357,10 @@ spec:
                             type: string
                           command:
                             type: string
-                          deployTokenInjection:
-                            type: boolean
                           id:
                             type: string
                           name:
                             type: string
-                          projectKeyInjection:
-                            type: boolean
                           service:
                             type: string
                           sshHost:
@@ -456,14 +448,10 @@ spec:
                             type: string
                           command:
                             type: string
-                          deployTokenInjection:
-                            type: boolean
                           id:
                             type: string
                           name:
                             type: string
-                          projectKeyInjection:
-                            type: boolean
                           service:
                             type: string
                           sshHost:
@@ -553,14 +541,10 @@ spec:
                             type: string
                           command:
                             type: string
-                          deployTokenInjection:
-                            type: boolean
                           id:
                             type: string
                           name:
                             type: string
-                          projectKeyInjection:
-                            type: boolean
                           service:
                             type: string
                           sshHost:

--- a/config/crd/bases/crd.lagoon.sh_lagoontasks.yaml
+++ b/config/crd/bases/crd.lagoon.sh_lagoontasks.yaml
@@ -132,14 +132,10 @@ spec:
                     type: string
                   command:
                     type: string
-                  deployTokenInjection:
-                    type: boolean
                   id:
                     type: string
                   name:
                     type: string
-                  projectKeyInjection:
-                    type: boolean
                   service:
                     type: string
                   sshHost:
@@ -254,14 +250,10 @@ spec:
                             type: string
                           command:
                             type: string
-                          deployTokenInjection:
-                            type: boolean
                           id:
                             type: string
                           name:
                             type: string
-                          projectKeyInjection:
-                            type: boolean
                           service:
                             type: string
                           sshHost:
@@ -347,14 +339,10 @@ spec:
                             type: string
                           command:
                             type: string
-                          deployTokenInjection:
-                            type: boolean
                           id:
                             type: string
                           name:
                             type: string
-                          projectKeyInjection:
-                            type: boolean
                           service:
                             type: string
                           sshHost:
@@ -442,14 +430,10 @@ spec:
                             type: string
                           command:
                             type: string
-                          deployTokenInjection:
-                            type: boolean
                           id:
                             type: string
                           name:
                             type: string
-                          projectKeyInjection:
-                            type: boolean
                           service:
                             type: string
                           sshHost:
@@ -539,14 +523,10 @@ spec:
                             type: string
                           command:
                             type: string
-                          deployTokenInjection:
-                            type: boolean
                           id:
                             type: string
                           name:
                             type: string
-                          projectKeyInjection:
-                            type: boolean
                           service:
                             type: string
                           sshHost:

--- a/internal/messenger/tasks_handler.go
+++ b/internal/messenger/tasks_handler.go
@@ -264,12 +264,6 @@ func (m *Messenger) ActiveStandbySwitch(namespace string, jobSpec *lagoonv1beta1
 
 // AdvancedTask handles running the ingress migrations.
 func (m *Messenger) AdvancedTask(namespace string, jobSpec *lagoonv1beta1.LagoonTaskSpec) error {
-	if jobSpec.Task.DeployTokenInjection {
-		jobSpec.AdvancedTask.DeployerToken = jobSpec.Task.DeployTokenInjection
-	}
-	if jobSpec.Task.ProjectKeyInjection {
-		jobSpec.AdvancedTask.SSHKey = jobSpec.Task.ProjectKeyInjection
-	}
 	return m.createAdvancedTask(namespace, jobSpec, nil)
 }
 


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

This reverts the changes made in #225 and implements a custom unmarshal function to convert the 1|0 bools to golang booleans

Since the main chart CRDs were never updated, the CRD change within this is somewhat acceptable to revert for now since the recommended install method is via helm.