### PR TITLE
chore: flag wrap k8upv2 support

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -32,3 +32,4 @@ spec:
         - "--enable-qos"
         - "--qos-max-builds=3"
         - "--enable-deprecated-apis"
+        - "--lagoon-feature-flag-support-k8upv2"

--- a/internal/messenger/messenger.go
+++ b/internal/messenger/messenger.go
@@ -36,6 +36,7 @@ type Messenger struct {
 	AdvancedTaskDeployTokenInjection bool
 	DeletionHandler                  *deletions.Deletions
 	EnableDebug                      bool
+	SupportK8upV2                    bool
 	Cache                            *expirable.LRU[string, string]
 }
 
@@ -51,6 +52,7 @@ func New(config mq.Config,
 	advancedTaskDeployTokenInjection bool,
 	deletionHandler *deletions.Deletions,
 	enableDebug bool,
+	supportK8upV2 bool,
 	cache *expirable.LRU[string, string],
 ) *Messenger {
 	return &Messenger{
@@ -65,6 +67,7 @@ func New(config mq.Config,
 		AdvancedTaskDeployTokenInjection: advancedTaskDeployTokenInjection,
 		DeletionHandler:                  deletionHandler,
 		EnableDebug:                      enableDebug,
+		SupportK8upV2:                    supportK8upV2,
 		Cache:                            cache,
 	}
 }

--- a/internal/messenger/tasks_restore.go
+++ b/internal/messenger/tasks_restore.go
@@ -53,20 +53,28 @@ func (m *Messenger) ResticRestore(namespace string, jobSpec *lagoonv1beta1.Lagoo
 		k8upv1Exists = true
 	}
 	// check the version, if there is no version in the payload, assume it is k8up v2
-	if vers == "backup.appuio.ch/v1alpha1" {
-		if k8upv1alpha1Exists {
-			return m.createv1alpha1Restore(opLog, namespace, jobSpec)
-		}
-	} else {
-		if k8upv1Exists {
-			if err := m.createv1Restore(opLog, namespace, jobSpec); err != nil {
-				return err
+	if m.SupportK8upV2 {
+		if vers == "backup.appuio.ch/v1alpha1" {
+			if k8upv1alpha1Exists {
+				return m.createv1alpha1Restore(opLog, namespace, jobSpec)
 			}
 		} else {
-			if k8upv1alpha1Exists {
-				if err := m.createv1alpha1Restore(opLog, namespace, jobSpec); err != nil {
+			if k8upv1Exists {
+				if err := m.createv1Restore(opLog, namespace, jobSpec); err != nil {
 					return err
 				}
+			} else {
+				if k8upv1alpha1Exists {
+					if err := m.createv1alpha1Restore(opLog, namespace, jobSpec); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	} else {
+		if k8upv1alpha1Exists {
+			if err := m.createv1alpha1Restore(opLog, namespace, jobSpec); err != nil {
+				return err
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -136,6 +136,7 @@ func main() {
 	var taskPodsToKeep int
 	var lffBackupWeeklyRandom bool
 	var lffHarborEnabled bool
+	var lffSupportK8UPv2 bool
 	var harborURL string
 	var harborAPI string
 	var harborUsername string
@@ -281,6 +282,8 @@ func main() {
 	flag.IntVar(&taskPodsToKeep, "num-task-pods-to-keep", 1, "The number of task pods to keep per namespace.")
 	flag.BoolVar(&lffBackupWeeklyRandom, "lagoon-feature-flag-backup-weekly-random", false,
 		"Tells Lagoon whether or not to use the \"weekly-random\" schedule for k8up backups.")
+	flag.BoolVar(&lffSupportK8UPv2, "lagoon-feature-flag-support-k8upv2", false,
+		"Tells Lagoon whether or not it can support k8up v2.")
 
 	flag.BoolVar(&tlsSkipVerify, "skip-tls-verify", false, "Flag to skip tls verification for http clients (harbor).")
 
@@ -644,6 +647,7 @@ func main() {
 		advancedTaskDeployToken,
 		deletion,
 		enableDebug,
+		lffSupportK8UPv2,
 		cache,
 	)
 


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

This feature wraps the support for k8up v2 (k8up.io/v1 crds) restores, and disabled by default.

