### PR TITLE
chore: set kubernetes versions in tests to 1.23 starting point

### DIFF
--- a/.github/workflows/remote-controller.yaml
+++ b/.github/workflows/remote-controller.yaml
@@ -16,20 +16,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kindest_node_version: [v1.21.12, v1.22.9]
+        kindest_node_version: [v1.23.6, v1.24.7, v1.25.3]
         harbor: ["1.9.0","1.12.2"]
         lagoon_build_image: ["uselagoon/build-deploy-image:main"]
         experimental: [false]
         include:
-          - kindest_node_version: v1.23.6
+          - kindest_node_version: v1.26.3
             harbor: "1.12.2"
             lagoon_build_image: "uselagoon/build-deploy-image:main"
             experimental: true
-          - kindest_node_version: v1.24.7
-            harbor: "1.12.2"
-            lagoon_build_image: "uselagoon/build-deploy-image:main"
-            experimental: true
-          - kindest_node_version: v1.25.3
+          - kindest_node_version: v1.27.3
             harbor: "1.12.2"
             lagoon_build_image: "uselagoon/build-deploy-image:main"
             experimental: true


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Drops kubernetes 1.21 and 1.22 from tests
