### PR TITLE
fix: use the lagoon task name for advanced tasks for cancellations to work

### DIFF
--- a/internal/messenger/tasks_handler.go
+++ b/internal/messenger/tasks_handler.go
@@ -276,9 +276,13 @@ func (m *Messenger) createAdvancedTask(namespace string, jobSpec *lagoonv1beta1.
 func createAdvancedTask(namespace string, jobSpec *lagoonv1beta1.LagoonTaskSpec, m *Messenger, additionalLabels map[string]string) error {
 	opLog := ctrl.Log.WithName("handlers").WithName("LagoonTasks")
 	// create the advanced task
+	taskName := fmt.Sprintf("lagoon-advanced-task-%s", helpers.RandString(6))
+	if jobSpec.Task.TaskName != "" {
+		taskName = jobSpec.Task.TaskName
+	}
 	task := lagoonv1beta1.LagoonTask{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "lagoon-advanced-task-" + helpers.RandString(6),
+			Name:      taskName,
 			Namespace: namespace,
 			Labels: map[string]string{
 				"lagoon.sh/taskType":   lagoonv1beta1.TaskTypeAdvanced.String(),


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Small fix to make sure advanced tasks are created using their lagoon-task name instead of a custom advanced task name. The lagoon.sh labels identify if it is an advanced or standard task already.