### PR TITLE
refactor: add basic unauthenticated registry passthrough

### DIFF
--- a/controllers/v1beta1/build_controller.go
+++ b/controllers/v1beta1/build_controller.go
@@ -75,6 +75,7 @@ type LagoonBuildReconciler struct {
 	LagoonFeatureFlags               map[string]string
 	LagoonAPIConfiguration           helpers.LagoonAPIConfiguration
 	ProxyConfig                      ProxyConfig
+	UnauthenticatedRegistry          string
 }
 
 // BackupConfig holds all the backup configuration settings

--- a/controllers/v1beta1/build_helpers.go
+++ b/controllers/v1beta1/build_helpers.go
@@ -507,7 +507,7 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 	})
 	podEnvs = append(podEnvs, corev1.EnvVar{
 		Name:  "REGISTRY",
-		Value: lagoonBuild.Spec.Project.Registry,
+		Value: r.UnauthenticatedRegistry,
 	})
 	// this is enabled by default for now
 	// eventually will be disabled by default because support for the generation/modification of this will

--- a/main.go
+++ b/main.go
@@ -175,6 +175,8 @@ func main() {
 	var enablePodProxy bool
 	var podsUseDifferentProxy bool
 
+	var unauthenticatedRegistry string
+
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080",
 		"The address the metric endpoint binds to.")
 	flag.StringVar(&lagoonTargetName, "lagoon-target-name", "ci-local-control-k8s",
@@ -334,6 +336,9 @@ func main() {
 	flag.StringVar(&harborWebhookEventTypes, "harbor-webhook-eventtypes", "SCANNING_FAILED,SCANNING_COMPLETED",
 		"The event types to use for the Lagoon webhook")
 
+	// this is for legacy reasons, and backwards compatability support due to removal of https://github.com/uselagoon/lagoon/pull/3659
+	flag.StringVar(&unauthenticatedRegistry, "unauthenticated-registry", "registry.lagoon.svc:5000", "An unauthenticated registry URL that could be used for local testing without a harbor")
+
 	// NS cleanup configuration
 	flag.BoolVar(&cleanNamespacesEnabled, "enable-namespace-cleanup", false,
 		"Tells the controller to remove namespaces marked for deletion with labels (lagoon.sh/expiration=<unixtimestamp>).")
@@ -406,6 +411,8 @@ func main() {
 	lagoonTokenPort = helpers.GetEnv("TASK_SSH_PORT", lagoonTokenPort)
 
 	nativeCronPodMinFrequency = helpers.GetEnvInt("NATIVE_CRON_POD_MINIMUM_FREQUENCY", nativeCronPodMinFrequency)
+
+	unauthenticatedRegistry = helpers.GetEnv("UNAUTHENTICATED_REGISTRY", unauthenticatedRegistry)
 
 	// harbor envvars
 	harborURL = helpers.GetEnv("HARBOR_URL", harborURL)
@@ -805,6 +812,7 @@ func main() {
 			HTTPSProxy: httpsProxy,
 			NoProxy:    noProxy,
 		},
+		UnauthenticatedRegistry: unauthenticatedRegistry,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LagoonBuild")
 		os.Exit(1)


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

With https://github.com/uselagoon/lagoon/pull/3659, core removed the support for this passthrough. This implements the passthrough in the remote-controller now for backwards compatibility for now.

This may get refactored again though if we revisit supporting more than Harbor in Lagoon remote clusters.
