### PR TITLE
feat: support cancelling restores

### DIFF
--- a/internal/helpers/helper_types.go
+++ b/internal/helpers/helper_types.go
@@ -33,7 +33,7 @@ func K8UPVersions(ctx context.Context, c client.Client) (bool, bool, error) {
 			return k8upv1alpha1Exists, k8upv1Exists, err
 		}
 	}
-	if crdv1alpha1.ObjectMeta.Name == "restores.backup.appuio.ch" {
+	if crdv1alpha1.Name == "restores.backup.appuio.ch" {
 		k8upv1alpha1Exists = true
 	}
 	crdv1 := &apiextensionsv1.CustomResourceDefinition{}
@@ -42,7 +42,7 @@ func K8UPVersions(ctx context.Context, c client.Client) (bool, bool, error) {
 			return k8upv1alpha1Exists, k8upv1Exists, err
 		}
 	}
-	if crdv1.ObjectMeta.Name == "restores.k8up.io" {
+	if crdv1.Name == "restores.k8up.io" {
 		k8upv1Exists = true
 	}
 	return k8upv1alpha1Exists, k8upv1Exists, nil

--- a/internal/helpers/helper_types.go
+++ b/internal/helpers/helper_types.go
@@ -1,5 +1,13 @@
 package helpers
 
+import (
+	"context"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
 // LagoonEnvironmentVariable is used to define Lagoon environment variables.
 type LagoonEnvironmentVariable struct {
 	Name  string `json:"name"`
@@ -14,4 +22,28 @@ type LagoonAPIConfiguration struct {
 	TokenPort string
 	SSHHost   string
 	SSHPort   string
+}
+
+func K8UPVersions(ctx context.Context, c client.Client) (bool, bool, error) {
+	k8upv1alpha1Exists := false
+	k8upv1Exists := false
+	crdv1alpha1 := &apiextensionsv1.CustomResourceDefinition{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "restores.backup.appuio.ch"}, crdv1alpha1); err != nil {
+		if err := IgnoreNotFound(err); err != nil {
+			return k8upv1alpha1Exists, k8upv1Exists, err
+		}
+	}
+	if crdv1alpha1.ObjectMeta.Name == "restores.backup.appuio.ch" {
+		k8upv1alpha1Exists = true
+	}
+	crdv1 := &apiextensionsv1.CustomResourceDefinition{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "restores.k8up.io"}, crdv1); err != nil {
+		if err := IgnoreNotFound(err); err != nil {
+			return k8upv1alpha1Exists, k8upv1Exists, err
+		}
+	}
+	if crdv1.ObjectMeta.Name == "restores.k8up.io" {
+		k8upv1Exists = true
+	}
+	return k8upv1alpha1Exists, k8upv1Exists, nil
 }

--- a/internal/messenger/consumer.go
+++ b/internal/messenger/consumer.go
@@ -322,13 +322,13 @@ func (m *Messenger) Consumer(targetName string) {
 			case "deploytarget:restic:backup:restore", "kubernetes:restic:backup:restore":
 				v1alpha1, v1, err := helpers.K8UPVersions(ctx, m.Client)
 				if err != nil {
-					//@TODO: send msg back to lagoon and update task to failed?
-					message.Ack(false) // ack to remove from queue
+					// @TODO: send msg back to lagoon and update task to failed?
+					_ = message.Ack(false) // ack to remove from queue
 					return
 				}
 				if !v1alpha1 && !v1 {
 					// k8up not installed
-					message.Ack(false) // ack to remove from queue
+					_ = message.Ack(false) // ack to remove from queue
 					return
 				}
 				opLog.Info(
@@ -354,13 +354,13 @@ func (m *Messenger) Consumer(targetName string) {
 			case "deploytarget:restic:cancel:restore":
 				v1alpha1, v1, err := helpers.K8UPVersions(ctx, m.Client)
 				if err != nil {
-					//@TODO: send msg back to lagoon and update task to failed?
-					message.Ack(false) // ack to remove from queue
+					// @TODO: send msg back to lagoon and update task to failed?
+					_ = message.Ack(false) // ack to remove from queue
 					return
 				}
 				if !v1alpha1 && !v1 {
 					// k8up not installed
-					message.Ack(false) // ack to remove from queue
+					_ = message.Ack(false) // ack to remove from queue
 					return
 				}
 				// if this is a request to cancel a restore attempt
@@ -380,8 +380,8 @@ func (m *Messenger) Consumer(targetName string) {
 							jobSpec.Environment.Name,
 						),
 					)
-					//@TODO: send msg back to lagoon and update task to failed?
-					message.Ack(false) // ack to remove from queue
+					// @TODO: send msg back to lagoon and update task to failed?
+					_ = message.Ack(false) // ack to remove from queue
 					return
 				}
 			case "deploytarget:route:migrate", "kubernetes:route:migrate", "openshift:route:migrate":

--- a/internal/messenger/consumer.go
+++ b/internal/messenger/consumer.go
@@ -320,6 +320,17 @@ func (m *Messenger) Consumer(targetName string) {
 					}
 				}
 			case "deploytarget:restic:backup:restore", "kubernetes:restic:backup:restore":
+				v1alpha1, v1, err := helpers.K8UPVersions(ctx, m.Client)
+				if err != nil {
+					//@TODO: send msg back to lagoon and update task to failed?
+					message.Ack(false) // ack to remove from queue
+					return
+				}
+				if !v1alpha1 && !v1 {
+					// k8up not installed
+					message.Ack(false) // ack to remove from queue
+					return
+				}
 				opLog.Info(
 					fmt.Sprintf(
 						"Received backup restoration for project %s, environment %s",
@@ -327,7 +338,7 @@ func (m *Messenger) Consumer(targetName string) {
 						jobSpec.Environment.Name,
 					),
 				)
-				err := m.ResticRestore(m.genNamespace(jobSpec), jobSpec)
+				err = m.ResticRestore(ctx, m.genNamespace(jobSpec), jobSpec, v1alpha1, v1, false)
 				if err != nil {
 					opLog.Error(err,
 						fmt.Sprintf(
@@ -338,6 +349,39 @@ func (m *Messenger) Consumer(targetName string) {
 					)
 					// @TODO: send msg back to lagoon and update task to failed?
 					_ = message.Ack(false) // ack to remove from queue
+					return
+				}
+			case "deploytarget:restic:cancel:restore":
+				v1alpha1, v1, err := helpers.K8UPVersions(ctx, m.Client)
+				if err != nil {
+					//@TODO: send msg back to lagoon and update task to failed?
+					message.Ack(false) // ack to remove from queue
+					return
+				}
+				if !v1alpha1 && !v1 {
+					// k8up not installed
+					message.Ack(false) // ack to remove from queue
+					return
+				}
+				// if this is a request to cancel a restore attempt
+				opLog.Info(
+					fmt.Sprintf(
+						"Received restore cancellation for project %s, environment %s",
+						jobSpec.Project.Name,
+						jobSpec.Environment.Name,
+					),
+				)
+				err = m.ResticRestore(ctx, m.genNamespace(jobSpec), jobSpec, v1alpha1, v1, true)
+				if err != nil {
+					opLog.Error(err,
+						fmt.Sprintf(
+							"Cancel restore for project %s, environment %s failed",
+							jobSpec.Project.Name,
+							jobSpec.Environment.Name,
+						),
+					)
+					//@TODO: send msg back to lagoon and update task to failed?
+					message.Ack(false) // ack to remove from queue
 					return
 				}
 			case "deploytarget:route:migrate", "kubernetes:route:migrate", "openshift:route:migrate":

--- a/internal/messenger/tasks_restore.go
+++ b/internal/messenger/tasks_restore.go
@@ -48,10 +48,8 @@ func (m *Messenger) ResticRestore(ctx context.Context, namespace string, jobSpec
 		} else {
 			if v1 {
 				handlev1 = true
-			} else {
-				if v1alpha1 {
-					handlev1alpha1 = true
-				}
+			} else if v1alpha1 {
+				handlev1alpha1 = true
 			}
 		}
 	} else {

--- a/test/e2e/testdata/cancel-restore.json
+++ b/test/e2e/testdata/cancel-restore.json
@@ -1,0 +1,17 @@
+{"properties":{"delivery_mode":2},"routing_key":"ci-local-controller-kubernetes:misc",
+    "payload":"{
+        \"misc\":{
+            \"miscResource\":\"eyJyZXN0b3JlTmFtZSI6InJlc3RvcmUtYmYwNzJhMC11cXhxbzQiLCJiYWNrdXBJZCI6ImJmMDcyYTA5ZTE3NzI2ZGE1NGFkYzc5OTM2ZWM4NzQ1NTIxOTkzNTk5ZDQxMjExZGZjOTQ2NmRmZDViYzMyYTUifQ==\"
+        },
+        \"key\":\"deploytarget:restic:cancel:restore\",
+        \"environment\":{
+            \"name\":\"main\",
+            \"openshiftProjectName\":\"nginx-example-main\"
+        },
+        \"project\":{
+            \"name\":\"nginx-example\"
+        },
+        \"advancedTask\":{}
+    }",
+"payload_encoding":"string"
+}


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Adds support for being able to cancel a k8up restore if received via rabbitmq (from the API)
