### PR TITLE
feat: support namespace expiry configmap

### DIFF
--- a/internal/utilities/pruner/namespace_pruner.go
+++ b/internal/utilities/pruner/namespace_pruner.go
@@ -71,7 +71,7 @@ func (p *Pruner) NamespacePruner() {
 					if ierr != nil {
 						opLog.Error(ierr, fmt.Sprintf("Unable to annotate namespace %s with %s", ns.Name, ExpirationPausedLabel))
 					}
-					continue //on to the next NS
+					continue // on to the next NS
 				}
 				delete = i
 			}
@@ -87,7 +87,7 @@ func (p *Pruner) NamespacePruner() {
 					if ierr != nil {
 						opLog.Error(ierr, fmt.Sprintf("Unable to annotate namespace %s with %s", ns.Name, ExpirationPausedLabel))
 					}
-					continue //on to the next NS
+					continue // on to the next NS
 				}
 				delete = i
 			}

--- a/internal/utilities/pruner/namespace_pruner.go
+++ b/internal/utilities/pruner/namespace_pruner.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/uselagoon/remote-controller/internal/helpers"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -54,17 +55,46 @@ func (p *Pruner) NamespacePruner() {
 			continue
 		}
 
-		if val, ok := ns.Labels[ExpirationLabel]; ok {
-			i, err := strconv.ParseInt(val, 10, 64)
-			if err != nil {
-				opLog.Error(err, fmt.Sprintf("Unable to convert %v from a unix timestamp - pausing deletion of namespace for manual intervention", val))
-				ierr := p.labelNamespace(ctx, ns, ExpirationPausedLabel, "true")
-				if ierr != nil {
-					opLog.Error(ierr, fmt.Sprintf("Unable to annotate namespace %s with %s", ns.Name, ExpirationPausedLabel))
+		delete := int64(0)
+
+		var expireConfig corev1.ConfigMap
+		err := p.Client.Get(ctx, client.ObjectKey{Name: "lagoon-namespace-expiry", Namespace: x.Namespace}, &expireConfig)
+		if helpers.IgnoreNotFound(err) != nil {
+			opLog.Error(err, fmt.Sprintf("unable to check namespace for lagoon-namespace-expiry: %s", ns.Name))
+			continue
+		} else {
+			if val, ok := expireConfig.Data["timestamp"]; ok {
+				i, err := strconv.ParseInt(val, 10, 64)
+				if err != nil {
+					opLog.Error(err, fmt.Sprintf("Unable to convert %v from a unix timestamp - pausing deletion of namespace for manual intervention", val))
+					ierr := p.labelNamespace(ctx, ns, ExpirationPausedLabel, "true")
+					if ierr != nil {
+						opLog.Error(ierr, fmt.Sprintf("Unable to annotate namespace %s with %s", ns.Name, ExpirationPausedLabel))
+					}
+					continue //on to the next NS
 				}
-				continue // on to the next NS
+				delete = i
 			}
-			expiryDate := time.Unix(i, 0)
+		}
+
+		// if the configmap doesn't exist, check the namespace labels
+		if delete == 0 {
+			if val, ok := ns.Labels[ExpirationLabel]; ok {
+				i, err := strconv.ParseInt(val, 10, 64)
+				if err != nil {
+					opLog.Error(err, fmt.Sprintf("Unable to convert %v from a unix timestamp - pausing deletion of namespace for manual intervention", val))
+					ierr := p.labelNamespace(ctx, ns, ExpirationPausedLabel, "true")
+					if ierr != nil {
+						opLog.Error(ierr, fmt.Sprintf("Unable to annotate namespace %s with %s", ns.Name, ExpirationPausedLabel))
+					}
+					continue //on to the next NS
+				}
+				delete = i
+			}
+		}
+
+		if delete > 0 {
+			expiryDate := time.Unix(delete, 0)
 			if expiryDate.Before(time.Now()) {
 				opLog.Info(fmt.Sprintf("Preparing to delete namespace: %v", x.Name))
 				err := p.DeletionHandler.ProcessDeletion(ctx, opLog, ns)
@@ -77,7 +107,6 @@ func (p *Pruner) NamespacePruner() {
 					continue
 				}
 				opLog.Info(fmt.Sprintf("Deleted namespace: %s", ns.Name))
-
 			} else {
 				opLog.Info(fmt.Sprintf("namespace %v is expiring later, so we skip", x.Name))
 				opLog.Info("Annotating namespace with future deletion details")


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Supports the existence of a `kind: ConfigMap` that contains `data["timestamp']` in the same format that the namespace timestamp label would contain. The standard namespace terminator cronjob will check for this and then check the namespace labels.

If the configmap exists, it will prefer this over the namespace label.

# Closing issues
