### PR TITLE
fix: if pod fails send failure correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20-alpine as builder
+FROM golang:1.20-alpine AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/controllers/v1beta1/podmonitor_buildhandlers.go
+++ b/controllers/v1beta1/podmonitor_buildhandlers.go
@@ -497,7 +497,7 @@ func (r *LagoonMonitorReconciler) updateDeploymentWithLogs(
 	// if the buildstatus is pending or running, or the cancel flag is provided
 	// send the update status to lagoon
 	if helpers.ContainsString(
-		helpers.BuildRunningPendingStatus,
+		helpers.BuildRunningPendingFailedStatus,
 		lagoonBuild.Labels["lagoon.sh/buildStatus"],
 	) || cancel {
 		opLog.Info(

--- a/controllers/v1beta1/podmonitor_taskhandlers.go
+++ b/controllers/v1beta1/podmonitor_taskhandlers.go
@@ -286,7 +286,7 @@ func (r *LagoonMonitorReconciler) updateTaskWithLogs(
 	// then update the task to reflect the current pod status
 	// we do this so we don't update the status of the task again
 	if helpers.ContainsString(
-		helpers.TaskRunningPendingStatus,
+		helpers.TaskRunningPendingFailedStatus,
 		lagoonTask.Labels["lagoon.sh/taskStatus"],
 	) || cancel {
 		opLog.Info(

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -36,6 +36,13 @@ var (
 		lagoonv1beta1.BuildStatusComplete.String(),
 		lagoonv1beta1.BuildStatusCancelled.String(),
 	}
+	// BuildRunningPendingStatus .
+	BuildRunningPendingFailedStatus = []string{
+		lagoonv1beta1.BuildStatusPending.String(),
+		lagoonv1beta1.BuildStatusQueued.String(),
+		lagoonv1beta1.BuildStatusRunning.String(),
+		lagoonv1beta1.BuildStatusFailed.String(),
+	}
 	// TaskRunningPendingStatus .
 	TaskRunningPendingStatus = []string{
 		lagoonv1beta1.TaskStatusPending.String(),
@@ -47,6 +54,13 @@ var (
 		lagoonv1beta1.TaskStatusFailed.String(),
 		lagoonv1beta1.TaskStatusComplete.String(),
 		lagoonv1beta1.TaskStatusCancelled.String(),
+	}
+	// TaskRunningPendingStatus .
+	TaskRunningPendingFailedStatus = []string{
+		lagoonv1beta1.TaskStatusPending.String(),
+		lagoonv1beta1.TaskStatusQueued.String(),
+		lagoonv1beta1.TaskStatusRunning.String(),
+		lagoonv1beta1.TaskStatusFailed.String(),
 	}
 )
 


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

If a pod fails in kubernetes with an ImagePullBackOff or CrashLoopBackOff, the controller would not pick this up and return the failure to the message queue.

This has a check for the pod failure status now so that a failure of either of these types will return to Lagoon the reason for the failure.
