### PR TITLE
refactor: queue processing and build conditions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@ RUN go mod download
 # Copy the go source
 COPY cmd/ cmd/
 COPY api/ api/
-COPY internal/controllers internal/controllers
+COPY internal/metrics internal/metrics
+COPY internal/utilities internal/utilities
 COPY internal/harbor internal/harbor
 COPY internal/helpers internal/helpers
 COPY internal/messenger internal/messenger
-COPY internal/metrics internal/metrics
-COPY internal/utilities internal/utilities
+COPY internal/controllers internal/controllers
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} GO111MODULE=on go build -a -o manager cmd/main.go

--- a/internal/controllers/v1beta2/podmonitor_buildhandlers.go
+++ b/internal/controllers/v1beta2/podmonitor_buildhandlers.go
@@ -564,11 +564,18 @@ Build %s
 			LastTransitionTime: metav1.NewTime(time.Now().UTC()),
 		}
 		_ = meta.SetStatusCondition(&lagoonBuild.Status.Conditions, condition)
+		// add every build step as its own status condition too
+		condition = metav1.Condition{
+			Type:               cases.Title(language.English, cases.NoLower).String(buildStep),
+			Reason:             buildCondition.String(),
+			Status:             metav1.ConditionTrue,
+			LastTransitionTime: metav1.NewTime(time.Now().UTC()),
+		}
+		_ = meta.SetStatusCondition(&lagoonBuild.Status.Conditions, condition)
 		mergeMap["status"] = map[string]interface{}{
 			"conditions": lagoonBuild.Status.Conditions,
 			"phase":      buildCondition.String(),
 		}
-
 		// get the configmap for lagoon-env so we can use it for updating the deployment in lagoon
 		var lagoonEnv corev1.ConfigMap
 		if err := r.Get(ctx, types.NamespacedName{


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Modifies the queue processor to only run when a build is created, cancelled, failed, or completed. Previously it would run on any update which could result in excessive attempts to try and reconcile builds during high activity periods.

Additionally, updates the CR for cancellations. Also the `BuildStep` status condition remains, but all other buildsteps will also be their own condition now to retain the full build step transitions of a build in the CR
