### PR TITLE
feat: add support for organization environment variables

### DIFF
--- a/api/lagoon/v1beta1/lagoonbuild_types.go
+++ b/api/lagoon/v1beta1/lagoonbuild_types.go
@@ -147,8 +147,9 @@ type Organization struct {
 
 // Variables contains the project and environment variables from lagoon.
 type LagoonVariables struct {
-	Project     []byte `json:"project,omitempty"`
-	Environment []byte `json:"environment,omitempty"`
+	Organization []byte `json:"organization,omitempty"`
+	Project      []byte `json:"project,omitempty"`
+	Environment  []byte `json:"environment,omitempty"`
 }
 
 // Branch contains the branch name used for a branch deployment.

--- a/api/lagoon/v1beta2/lagoonbuild_types.go
+++ b/api/lagoon/v1beta2/lagoonbuild_types.go
@@ -143,8 +143,9 @@ type Organization struct {
 
 // Variables contains the project and environment variables from lagoon.
 type LagoonVariables struct {
-	Project     []byte `json:"project,omitempty"`
-	Environment []byte `json:"environment,omitempty"`
+	Organization []byte `json:"organization,omitempty"`
+	Project      []byte `json:"project,omitempty"`
+	Environment  []byte `json:"environment,omitempty"`
 }
 
 // Branch contains the branch name used for a branch deployment.

--- a/config/crd/bases/crd.lagoon.sh_lagoonbuilds.yaml
+++ b/config/crd/bases/crd.lagoon.sh_lagoonbuilds.yaml
@@ -125,13 +125,16 @@ spec:
                   uiLink:
                     type: string
                   variables:
-                    description: Variables contains the project and environment variables
-                      from lagoon.
+                    description: Variables contains the organization, project,
+                      and environment variables from lagoon.
                     properties:
                       environment:
                         format: byte
                         type: string
                       project:
+                        format: byte
+                        type: string
+                      organization:
                         format: byte
                         type: string
                     type: object
@@ -812,13 +815,16 @@ spec:
                   uiLink:
                     type: string
                   variables:
-                    description: Variables contains the project and environment variables
-                      from lagoon.
+                    description: Variables contains the organization, project,
+                      and environment variables from lagoon.
                     properties:
                       environment:
                         format: byte
                         type: string
                       project:
+                        format: byte
+                        type: string
+                      organization:
                         format: byte
                         type: string
                     type: object

--- a/config/crd/bases/crd.lagoon.sh_lagoontasks.yaml
+++ b/config/crd/bases/crd.lagoon.sh_lagoontasks.yaml
@@ -120,13 +120,16 @@ spec:
                         type: string
                     type: object
                   variables:
-                    description: Variables contains the project and environment variables
-                      from lagoon.
+                    description: Variables contains the organization, project,
+                      and environment variables from lagoon.
                     properties:
                       environment:
                         format: byte
                         type: string
                       project:
+                        format: byte
+                        type: string
+                      organization:
                         format: byte
                         type: string
                     type: object
@@ -788,13 +791,16 @@ spec:
                         type: string
                     type: object
                   variables:
-                    description: Variables contains the project and environment variables
-                      from lagoon.
+                    description: Variables contains the organization, project,
+                      and environment variables from lagoon.
                     properties:
                       environment:
                         format: byte
                         type: string
                       project:
+                        format: byte
+                        type: string
+                      organization:
                         format: byte
                         type: string
                     type: object

--- a/internal/controllers/v1beta1/task_controller.go
+++ b/internal/controllers/v1beta1/task_controller.go
@@ -228,6 +228,16 @@ func (r *LagoonTaskReconciler) getTaskPodDeployment(ctx context.Context, lagoonT
 							Value: r.ProxyConfig.NoProxy,
 						})
 					}
+					if lagoonTask.Spec.Project.Variables.Organization != nil {
+						// if this is 2 bytes long, then it means its just an empty json array
+						// we only want to add it if it is more than 2 bytes
+						if len(lagoonTask.Spec.Project.Variables.Organization) > 2 {
+							dep.Spec.Template.Spec.Containers[idx].Env = append(dep.Spec.Template.Spec.Containers[idx].Env, corev1.EnvVar{
+								Name:  "LAGOON_ORGANIZATION_VARIABLES",
+								Value: string(lagoonTask.Spec.Project.Variables.Organization),
+							})
+						}
+					}
 					if lagoonTask.Spec.Project.Variables.Project != nil {
 						// if this is 2 bytes long, then it means its just an empty json array
 						// we only want to add it if it is more than 2 bytes
@@ -511,6 +521,16 @@ func (r *LagoonTaskReconciler) createAdvancedTask(ctx context.Context, lagoonTas
 			Name:  "TASK_DATA_ID",
 			Value: lagoonTask.Spec.Task.ID,
 		},
+	}
+	if lagoonTask.Spec.Project.Variables.Organization != nil {
+		// if this is 2 bytes long, then it means its just an empty json array
+		// we only want to add it if it is more than 2 bytes
+		if len(lagoonTask.Spec.Project.Variables.Organization) > 2 {
+			podEnvs = append(podEnvs, corev1.EnvVar{
+				Name:  "LAGOON_ORGANIZATION_VARIABLES",
+				Value: string(lagoonTask.Spec.Project.Variables.Organization),
+			})
+		}
 	}
 	if lagoonTask.Spec.Project.Variables.Project != nil {
 		// if this is 2 bytes long, then it means its just an empty json array

--- a/internal/controllers/v1beta2/build_helpers.go
+++ b/internal/controllers/v1beta2/build_helpers.go
@@ -588,8 +588,10 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 	// if local/regional harbor is enabled
 	if r.LFFHarborEnabled {
 		// unmarshal the project variables
+		lagoonOrganizationVariables := &[]helpers.LagoonEnvironmentVariable{}
 		lagoonProjectVariables := &[]helpers.LagoonEnvironmentVariable{}
 		lagoonEnvironmentVariables := &[]helpers.LagoonEnvironmentVariable{}
+		json.Unmarshal(lagoonBuild.Spec.Project.Variables.Organization, lagoonOrganizationVariables)
 		json.Unmarshal(lagoonBuild.Spec.Project.Variables.Project, lagoonProjectVariables)
 		json.Unmarshal(lagoonBuild.Spec.Project.Variables.Environment, lagoonEnvironmentVariables)
 		// check if INTERNAL_REGISTRY_SOURCE_LAGOON is defined, and if it isn't true
@@ -597,7 +599,8 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 		// if it is false, or not set, then we use what is provided by this controller
 		// this allows us to make it so a specific environment or the project entirely
 		// can still use whats provided by lagoon
-		if !helpers.VariableExists(lagoonProjectVariables, "INTERNAL_REGISTRY_SOURCE_LAGOON", "true") ||
+		if !helpers.VariableExists(lagoonOrganizationVariables, "INTERNAL_REGISTRY_SOURCE_LAGOON", "true") ||
+			!helpers.VariableExists(lagoonProjectVariables, "INTERNAL_REGISTRY_SOURCE_LAGOON", "true") ||
 			!helpers.VariableExists(lagoonEnvironmentVariables, "INTERNAL_REGISTRY_SOURCE_LAGOON", "true") {
 			// source the robot credential, and inject it into the lagoon project variables
 			// this will overwrite what is provided by lagoon (if lagoon has provided them)
@@ -632,6 +635,16 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 			// these values are being overwritten and injected directly into the build pod to be consumed
 			// by the build pod image
 			lagoonBuild.Spec.Project.Variables.Project, _ = json.Marshal(lagoonProjectVariables)
+		}
+	}
+	if lagoonBuild.Spec.Project.Variables.Organization != nil {
+		// if this is 2 bytes long, then it means its just an empty json array
+		// we only want to add it if it is more than 2 bytes
+		if len(lagoonBuild.Spec.Project.Variables.Organization) > 2 {
+			podEnvs = append(podEnvs, corev1.EnvVar{
+				Name:  "LAGOON_ORGANIZATION_VARIABLES",
+				Value: string(lagoonBuild.Spec.Project.Variables.Organization),
+			})
 		}
 	}
 	if lagoonBuild.Spec.Project.Variables.Project != nil {

--- a/internal/controllers/v1beta2/task_controller.go
+++ b/internal/controllers/v1beta2/task_controller.go
@@ -225,6 +225,16 @@ func (r *LagoonTaskReconciler) getTaskPodDeployment(ctx context.Context, lagoonT
 							Value: r.ProxyConfig.NoProxy,
 						})
 					}
+					if lagoonTask.Spec.Project.Variables.Organization != nil {
+						// if this is 2 bytes long, then it means its just an empty json array
+						// we only want to add it if it is more than 2 bytes
+						if len(lagoonTask.Spec.Project.Variables.Organization) > 2 {
+							dep.Spec.Template.Spec.Containers[idx].Env = append(dep.Spec.Template.Spec.Containers[idx].Env, corev1.EnvVar{
+								Name:  "LAGOON_ORGANIZATION_VARIABLES",
+								Value: string(lagoonTask.Spec.Project.Variables.Organization),
+							})
+						}
+					}
 					if lagoonTask.Spec.Project.Variables.Project != nil {
 						// if this is 2 bytes long, then it means its just an empty json array
 						// we only want to add it if it is more than 2 bytes
@@ -514,6 +524,16 @@ func (r *LagoonTaskReconciler) createAdvancedTask(ctx context.Context, lagoonTas
 			Name:  "TASK_DATA_ID",
 			Value: lagoonTask.Spec.Task.ID,
 		},
+	}
+	if lagoonTask.Spec.Project.Variables.Organization != nil {
+		// if this is 2 bytes long, then it means its just an empty json array
+		// we only want to add it if it is more than 2 bytes
+		if len(lagoonTask.Spec.Project.Variables.Organization) > 2 {
+			podEnvs = append(podEnvs, corev1.EnvVar{
+				Name:  "LAGOON_ORGANIZATION_VARIABLES",
+				Value: string(lagoonTask.Spec.Project.Variables.Organization),
+			})
+		}
 	}
 	if lagoonTask.Spec.Project.Variables.Project != nil {
 		// if this is 2 bytes long, then it means its just an empty json array


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [x] Affected Issues have been mentioned in the Closing issues section
- [x] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Updates lagoon-remote so that it will make organization environment variables sent by lagoon-core available to the build-deploy-tool.

# Closing issues

Part of https://github.com/uselagoon/lagoon/issues/3602