### PR TITLE
fix: use the correct label names for build pod checks

### DIFF
--- a/internal/controllers/v1beta2/podmonitor_buildhandlers.go
+++ b/internal/controllers/v1beta2/podmonitor_buildhandlers.go
@@ -158,17 +158,11 @@ func (r *LagoonMonitorReconciler) buildLogsToLagoonLogs(
 			buildStep = value
 		}
 		envName := namespace.ObjectMeta.Labels["lagoon.sh/environment"]
-		eID, _ := strconv.Atoi(namespace.ObjectMeta.Labels["lagoon.sh/environment"])
+		eID, _ := strconv.Atoi(namespace.ObjectMeta.Labels["lagoon.sh/environmentId"])
 		envID := helpers.UintPtr(uint(eID))
-		projectName := namespace.ObjectMeta.Labels["lagoon.sh/environment"]
-		pID, _ := strconv.Atoi(namespace.ObjectMeta.Labels["lagoon.sh/environment"])
+		projectName := namespace.ObjectMeta.Labels["lagoon.sh/project"]
+		pID, _ := strconv.Atoi(namespace.ObjectMeta.Labels["lagoon.sh/projectId"])
 		projectID := helpers.UintPtr(uint(pID))
-		if lagoonBuild != nil {
-			envName = lagoonBuild.Spec.Project.Environment
-			envID = lagoonBuild.Spec.Project.EnvironmentID
-			projectName = lagoonBuild.Spec.Project.Name
-			projectID = lagoonBuild.Spec.Project.ID
-		}
 		remoteId := string(jobPod.ObjectMeta.UID)
 		if value, ok := jobPod.Labels["lagoon.sh/buildRemoteID"]; ok {
 			remoteId = value
@@ -256,18 +250,12 @@ func (r *LagoonMonitorReconciler) updateDeploymentAndEnvironmentTask(
 			})
 			time.Sleep(2 * time.Second) // smol sleep to reduce race of final messages with previous messages
 		}
-		envName := lagoonBuild.Spec.Project.Environment
-		envID := lagoonBuild.Spec.Project.EnvironmentID
-		projectName := lagoonBuild.Spec.Project.Name
-		projectID := lagoonBuild.Spec.Project.ID
-		if lagoonBuild == nil {
-			envName = namespace.ObjectMeta.Labels["lagoon.sh/environment"]
-			eID, _ := strconv.Atoi(namespace.ObjectMeta.Labels["lagoon.sh/environment"])
-			envID = helpers.UintPtr(uint(eID))
-			projectName = namespace.ObjectMeta.Labels["lagoon.sh/environment"]
-			pID, _ := strconv.Atoi(namespace.ObjectMeta.Labels["lagoon.sh/environment"])
-			projectID = helpers.UintPtr(uint(pID))
-		}
+		envName := namespace.ObjectMeta.Labels["lagoon.sh/environment"]
+		eID, _ := strconv.Atoi(namespace.ObjectMeta.Labels["lagoon.sh/environmentId"])
+		envID := helpers.UintPtr(uint(eID))
+		projectName := namespace.ObjectMeta.Labels["lagoon.sh/project"]
+		pID, _ := strconv.Atoi(namespace.ObjectMeta.Labels["lagoon.sh/projectId"])
+		projectID := helpers.UintPtr(uint(pID))
 		remoteId := string(jobPod.ObjectMeta.UID)
 		if value, ok := jobPod.Labels["lagoon.sh/buildRemoteID"]; ok {
 			remoteId = value
@@ -393,17 +381,11 @@ func (r *LagoonMonitorReconciler) buildStatusLogsToLagoonLogs(
 			buildStep = value
 		}
 		envName := namespace.ObjectMeta.Labels["lagoon.sh/environment"]
-		eID, _ := strconv.Atoi(namespace.ObjectMeta.Labels["lagoon.sh/environment"])
+		eID, _ := strconv.Atoi(namespace.ObjectMeta.Labels["lagoon.sh/environmentId"])
 		envID := helpers.UintPtr(uint(eID))
-		projectName := namespace.ObjectMeta.Labels["lagoon.sh/environment"]
-		pID, _ := strconv.Atoi(namespace.ObjectMeta.Labels["lagoon.sh/environment"])
+		projectName := namespace.ObjectMeta.Labels["lagoon.sh/project"]
+		pID, _ := strconv.Atoi(namespace.ObjectMeta.Labels["lagoon.sh/projectId"])
 		projectID := helpers.UintPtr(uint(pID))
-		if lagoonBuild != nil {
-			envName = lagoonBuild.Spec.Project.Environment
-			envID = lagoonBuild.Spec.Project.EnvironmentID
-			projectName = lagoonBuild.Spec.Project.Name
-			projectID = lagoonBuild.Spec.Project.ID
-		}
 		msg := schema.LagoonLog{
 			Severity: "info",
 			Project:  projectName,


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Fixes a bug in the deleting completed build/buildpod checks that meant the wrong information was sent back to core. This corrects the labels to use the right label names so that the correct data is returned.

This only impacted builds that were completed/failed and get pruned by the buildpod/build pruner process.