### PR TITLE
refactor: build pod deletion to reduce duplicate messages

### DIFF
--- a/internal/controllers/v1beta2/build_controller.go
+++ b/internal/controllers/v1beta2/build_controller.go
@@ -319,6 +319,8 @@ func (r *LagoonBuildReconciler) getOrCreateBuildResource(ctx context.Context, la
 			"crd.lagoon.sh/version": crdVersion,
 		},
 	)
+	// add the finalizer to the new build
+	newBuild.Finalizers = append(newBuild.Finalizers, buildFinalizer)
 	// all new builds start as "queued" but will transition to pending or running fairly quickly
 	// unless they are actually queued :D
 	newBuild.Status.Phase = "Queued"

--- a/internal/controllers/v1beta2/build_deletionhandlers.go
+++ b/internal/controllers/v1beta2/build_deletionhandlers.go
@@ -6,15 +6,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/uselagoon/machinery/api/schema"
 	lagooncrd "github.com/uselagoon/remote-controller/api/lagoon/v1beta2"
 	"github.com/uselagoon/remote-controller/internal/helpers"
-	"gopkg.in/matryer/try.v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -31,127 +30,18 @@ func (r *LagoonBuildReconciler) deleteExternalResources(
 	req ctrl.Request,
 ) error {
 	// get any running pods that this build may have already created
-	lagoonBuildPod := corev1.Pod{}
-	err := r.Get(ctx, types.NamespacedName{
-		Namespace: lagoonBuild.ObjectMeta.Namespace,
-		Name:      lagoonBuild.ObjectMeta.Name,
-	}, &lagoonBuildPod)
+	err := lagooncrd.DeleteBuildPod(ctx, r.Client, opLog, lagoonBuild, req.NamespacedName, r.ControllerNamespace)
 	if err != nil {
-		opLog.Info(fmt.Sprintf("Unable to find a build pod for %s, continuing to process build deletion", lagoonBuild.ObjectMeta.Name))
-		// handle updating lagoon for a deleted build with no running pod
-		// only do it if the build status is Pending or Running though
-		err = r.updateCancelledDeploymentWithLogs(ctx, req, *lagoonBuild)
-		if err != nil {
-			opLog.Error(err, "unable to update the lagoon with LagoonBuild result")
-		}
-	} else {
-		opLog.Info(fmt.Sprintf("Found build pod for %s, deleting it", lagoonBuild.ObjectMeta.Name))
-		// handle updating lagoon for a deleted build with a running pod
-		// only do it if the build status is Pending or Running though
-		// delete the pod, let the pod deletion handler deal with the cleanup there
-		if err := r.Delete(ctx, &lagoonBuildPod); err != nil {
-			opLog.Error(err, fmt.Sprintf("Unable to delete the the LagoonBuild pod %s", lagoonBuild.ObjectMeta.Name))
-		}
-		// check that the pod is deleted before continuing, this allows the pod deletion to happen
-		// and the pod deletion process in the LagoonMonitor controller to be able to send what it needs back to lagoon
-		// this 1 minute timeout will just hold up the deletion of `LagoonBuild` resources only if a build pod exists
-		// if the 1 minute timeout is reached the worst that happens is a deployment will show as running
-		// but cancelling the deployment in lagoon will force it to go to a cancelling state in the lagoon api
-		// @TODO: we could use finalizers on the build pods, but to avoid holding up other processes we can just give up after waiting for a minute
-		try.MaxRetries = 12
-		err = try.Do(func(attempt int) (bool, error) {
-			var podErr error
-			err := r.Get(ctx, types.NamespacedName{
-				Namespace: lagoonBuild.ObjectMeta.Namespace,
-				Name:      lagoonBuild.ObjectMeta.Name,
-			}, &lagoonBuildPod)
+		if strings.Contains(err.Error(), "unable to find a build pod for") {
+			err = r.updateCancelledDeploymentWithLogs(ctx, req, *lagoonBuild)
 			if err != nil {
-				// the pod doesn't exist anymore, so exit the retry
-				podErr = nil
-				opLog.Info(fmt.Sprintf("Pod %s deleted", lagoonBuild.ObjectMeta.Name))
-			} else {
-				// if the pod still exists wait 5 seconds before trying again
-				time.Sleep(5 * time.Second)
-				podErr = fmt.Errorf("pod %s still exists", lagoonBuild.ObjectMeta.Name)
-				opLog.Info(fmt.Sprintf("Pod %s still exists", lagoonBuild.ObjectMeta.Name))
+				opLog.Error(err, "unable to update the lagoon with LagoonBuild result")
 			}
-			return attempt < 12, podErr
-		})
-		if err != nil {
+		} else {
 			return err
 		}
 	}
-
-	// if the LagoonBuild is deleted, then check if the only running build is the one being deleted
-	// or if there are any pending builds that can be started
-	runningBuilds := &lagooncrd.LagoonBuildList{}
-	listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
-		client.InNamespace(lagoonBuild.ObjectMeta.Namespace),
-		client.MatchingLabels(map[string]string{
-			"lagoon.sh/buildStatus": lagooncrd.BuildStatusRunning.String(),
-			"lagoon.sh/controller":  r.ControllerNamespace,
-		}),
-	})
-	// list any builds that are running
-	if err := r.List(ctx, runningBuilds, listOption); err != nil {
-		opLog.Error(err, "unable to list builds in the namespace, there may be none or something went wrong")
-		// just return nil so the deletion of the resource isn't held up
-		return nil
-	}
-	newRunningBuilds := runningBuilds.Items
-	for _, runningBuild := range runningBuilds.Items {
-		// if there are any running builds, check if it is the one currently being deleted
-		if lagoonBuild.ObjectMeta.Name == runningBuild.ObjectMeta.Name {
-			// if the one being deleted is a running one, remove it from the list of running builds
-			newRunningBuilds = lagooncrd.RemoveBuild(newRunningBuilds, runningBuild)
-		}
-	}
-	// if the number of runningBuilds is 0 (excluding the one being deleted)
-	if len(newRunningBuilds) == 0 {
-		pendingBuilds := &lagooncrd.LagoonBuildList{}
-		listOption = (&client.ListOptions{}).ApplyOptions([]client.ListOption{
-			client.InNamespace(lagoonBuild.ObjectMeta.Namespace),
-			client.MatchingLabels(map[string]string{
-				"lagoon.sh/buildStatus": lagooncrd.BuildStatusPending.String(),
-				"lagoon.sh/controller":  r.ControllerNamespace,
-			}),
-		})
-		if err := r.List(ctx, pendingBuilds, listOption); err != nil {
-			opLog.Error(err, "unable to list builds in the namespace, there may be none or something went wrong")
-			// just return nil so the deletion of the resource isn't held up
-			return nil
-		}
-		newPendingBuilds := pendingBuilds.Items
-		for _, pendingBuild := range pendingBuilds.Items {
-			// if there are any pending builds, check if it is the one currently being deleted
-			if lagoonBuild.ObjectMeta.Name == pendingBuild.ObjectMeta.Name {
-				// if the one being deleted a the pending one, remove it from the list of pending builds
-				newPendingBuilds = lagooncrd.RemoveBuild(newPendingBuilds, pendingBuild)
-			}
-		}
-		// sort the pending builds by creation timestamp
-		sort.Slice(newPendingBuilds, func(i, j int) bool {
-			return newPendingBuilds[i].ObjectMeta.CreationTimestamp.Before(&newPendingBuilds[j].ObjectMeta.CreationTimestamp)
-		})
-		// if there are more than 1 pending builds (excluding the one being deleted), update the oldest one to running
-		if len(newPendingBuilds) > 0 {
-			pendingBuild := pendingBuilds.Items[0].DeepCopy()
-			mergePatch, _ := json.Marshal(map[string]interface{}{
-				"metadata": map[string]interface{}{
-					"labels": map[string]interface{}{
-						"lagoon.sh/buildStatus": lagooncrd.BuildStatusRunning.String(),
-					},
-				},
-			})
-			if err := r.Patch(ctx, pendingBuild, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
-				opLog.Error(err, "unable to update pending build to running status")
-				return nil
-			}
-		} else {
-			opLog.Info("No pending builds")
-		}
-	}
-	return nil
+	return lagooncrd.DeleteBuildResources(ctx, r.Client, opLog, lagoonBuild, req.NamespacedName, r.ControllerNamespace)
 }
 
 func (r *LagoonBuildReconciler) updateCancelledDeploymentWithLogs(

--- a/internal/controllers/v1beta2/build_qoshandler.go
+++ b/internal/controllers/v1beta2/build_qoshandler.go
@@ -2,14 +2,11 @@ package v1beta2
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/go-logr/logr"
 	lagooncrd "github.com/uselagoon/remote-controller/api/lagoon/v1beta2"
-	"github.com/uselagoon/remote-controller/internal/helpers"
 	"github.com/uselagoon/remote-controller/internal/metrics"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -145,22 +142,6 @@ func (r *LagoonBuildReconciler) processQueue(ctx context.Context, opLog logr.Log
 						}
 						// don't handle the queued process for this build, continue to next in the list
 						continue
-					}
-					// The object is not being deleted, so if it does not have our finalizer,
-					// then lets add the finalizer and update the object. This is equivalent
-					// registering our finalizer.
-					if !helpers.ContainsString(pBuild.ObjectMeta.Finalizers, buildFinalizer) {
-						pBuild.ObjectMeta.Finalizers = append(pBuild.ObjectMeta.Finalizers, buildFinalizer)
-						// use patches to avoid update errors
-						mergePatch, _ := json.Marshal(map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"finalizers": pBuild.ObjectMeta.Finalizers,
-							},
-						})
-						if err := r.Patch(ctx, &pBuild, client.RawPatch(types.MergePatchType, mergePatch)); err != nil {
-							runningProcessQueue = false
-							return err
-						}
 					}
 				}
 				// update the build to be queued, and add a log message with the build log with the current position in the queue

--- a/internal/controllers/v1beta2/buildpodmonitor_handlers.go
+++ b/internal/controllers/v1beta2/buildpodmonitor_handlers.go
@@ -508,45 +508,11 @@ Build %s
 			allContainerLogs = logs
 		}
 
-		published := false
-		if helpers.ContainsString(
-			lagooncrd.BuildCompletedCancelledFailedStatus,
-			lagoonBuild.Labels["lagoon.sh/buildStatus"],
-		) {
-			// if the build has completed, failed, or been cancelled
-			published = true
-			// check if this build has already published data or not
-			if value, ok := lagoonBuild.Labels["build.lagoon.sh/published"]; ok {
-				published, _ = strconv.ParseBool(value)
-			}
-		}
-		// if it hasn't published after completion, do that now
-		if !published {
-			// do any message publishing here, and update any pending messages if needed
-			if err = r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &jobPod, namespace, buildCondition.ToLower()); err != nil {
-				opLog.Error(err, "unable to publish build status logs")
-				published = false
-			}
-			if err = r.updateDeploymentAndEnvironmentTask(ctx, opLog, &lagoonBuild, &jobPod, namespace, buildCondition.ToLower()); err != nil {
-				opLog.Error(err, "unable to publish build update")
-				published = false
-			}
-			// if the container logs can't be retrieved, we don't want to send any build logs back, as this will nuke
-			// any previously received logs
-			if !strings.Contains(string(allContainerLogs), "unable to retrieve container logs for containerd") {
-				if err = r.buildLogsToLagoonLogs(opLog, &lagoonBuild, &jobPod, namespace, buildCondition.ToLower(), allContainerLogs); err != nil {
-					opLog.Error(err, "unable to publish build logs")
-					published = false
-				}
-			}
-		}
-
 		mergeMap := map[string]interface{}{
 			"metadata": map[string]interface{}{
 				"labels": map[string]interface{}{
-					"lagoon.sh/buildStatus":     buildCondition.String(),
-					"lagoon.sh/buildStarted":    "true",
-					"build.lagoon.sh/published": fmt.Sprintf("%t", published),
+					"lagoon.sh/buildStatus":  buildCondition.String(),
+					"lagoon.sh/buildStarted": "true",
 				},
 			},
 		}
@@ -556,6 +522,21 @@ Build %s
 		mergeMap["status"] = map[string]interface{}{
 			"conditions": lagoonBuild.Status.Conditions,
 			"phase":      buildCondition.String(),
+		}
+
+		// do any message publishing here, and update any pending messages if needed
+		if err = r.buildStatusLogsToLagoonLogs(ctx, opLog, &lagoonBuild, &jobPod, namespace, buildCondition.ToLower()); err != nil {
+			opLog.Error(err, "unable to publish build status logs")
+		}
+		if err = r.updateDeploymentAndEnvironmentTask(ctx, opLog, &lagoonBuild, &jobPod, namespace, buildCondition.ToLower()); err != nil {
+			opLog.Error(err, "unable to publish build update")
+		}
+		// if the container logs can't be retrieved, we don't want to send any build logs back, as this will nuke
+		// any previously received logs
+		if !strings.Contains(string(allContainerLogs), "unable to retrieve container logs for containerd") {
+			if err = r.buildLogsToLagoonLogs(opLog, &lagoonBuild, &jobPod, namespace, buildCondition.ToLower(), allContainerLogs); err != nil {
+				opLog.Error(err, "unable to publish build logs")
+			}
 		}
 
 		mergePatch, _ := json.Marshal(mergeMap)


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Refactors the way the build pod deletion process runs to reduce the potential for duplicate messages due to a race condition in the previous implementation.

# Closing issues

closes #289 
closes #290