### PR TITLE
feat: support multiple docker hosts with dockerhost service injection

### DIFF
--- a/.github/workflows/remote-controller.yaml
+++ b/.github/workflows/remote-controller.yaml
@@ -128,3 +128,13 @@ jobs:
     - name: Run github/test-e2e
       run: |
         make github/test-e2e HARBOR_VERSION=${{matrix.harbor}} OVERRIDE_BUILD_DEPLOY_DIND_IMAGE="${{matrix.lagoon_build_image}}" KIND_NETWORK=kind
+
+  rerun-failed-jobs:
+      runs-on: ubuntu-latest
+      needs: [ test-suite ]
+      if: failure()
+      steps:
+        - name: Rerun failed jobs in the current workflow
+          env:
+            GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          run: gh run rerun ${{ github.run_id }} --failed

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY internal/utilities internal/utilities
 COPY internal/harbor internal/harbor
 COPY internal/helpers internal/helpers
 COPY internal/messenger internal/messenger
+COPY internal/dockerhost internal/dockerhost
 COPY internal/controllers internal/controllers
 
 # Build

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -752,15 +752,18 @@ func main() {
 
 	reuseCache, _ := lru.New[string, string](1000)
 	buildCache, _ := lru.New[string, string](1000)
-	switch dockerHostReuseType {
-	case "namespace", "project", "organization":
-		// nothing to do here
-	default:
+	dockerhostResuseTypes := map[string]bool{
+		"namespace":    true,
+		"project":      true,
+		"organization": true,
+	}
+	if !dockerhostResuseTypes[dockerHostReuseType] {
 		setupLog.Error(fmt.Errorf("unsupported docker-host reuse type"), "problem configuring docker-host handler")
 		os.Exit(1)
 	}
 	dockerhosts := dockerhost.New(
 		mgr.GetClient(),
+		ctrl.Log.WithName("dockerhost"),
 		dockerHostNamespace,
 		dockerHostReuseType,
 		reuseCache,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,6 +34,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/uselagoon/remote-controller/internal/dockerhost"
 	"github.com/uselagoon/remote-controller/internal/harbor"
 	"github.com/uselagoon/remote-controller/internal/helpers"
 	"github.com/uselagoon/remote-controller/internal/utilities/deletions"
@@ -44,6 +45,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	k8upv1 "github.com/k8up-io/k8up/v2/api/v1"
 	lagoonv1beta2 "github.com/uselagoon/remote-controller/api/lagoon/v1beta2"
@@ -193,6 +195,8 @@ func main() {
 	var podsUseDifferentProxy bool
 
 	var unauthenticatedRegistry string
+	var dockerHostNamespace string
+	var dockerHostReuseType string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -417,6 +421,11 @@ func main() {
 	flag.IntVar(&pvcRetryAttempts, "delete-pvc-retry-attempts", 30, "How many attempts to check that PVCs have been removed (default 30).")
 	flag.IntVar(&pvcRetryInterval, "delete-pvc-retry-interval", 10, "The number of seconds between each retry attempt (default 10).")
 
+	flag.StringVar(&dockerHostNamespace, "docker-host-namespace", "lagoon", "The name of the docker-host namespace")
+	flag.StringVar(&dockerHostReuseType, "docker-host-reuse-type", "namespace",
+		`The resource type (namespace, project, organization) to use when assigning a docker-host to a build to preference an already used dockerhost
+		eg. If project is defined, all builds from a project will prefer to build on the same docker-host where possible`)
+
 	flag.Parse()
 
 	// get overrides from environment variables
@@ -497,6 +506,9 @@ func main() {
 	fastlyServiceID = helpers.GetEnv("FASTLY_SERVICE_ID", fastlyServiceID)
 	// this is used to control setting the service id into build pods
 	fastlyWatchStatus = helpers.GetEnvBool("FASTLY_WATCH_STATUS", fastlyWatchStatus)
+
+	dockerHostNamespace = helpers.GetEnv("DOCKERHOST_NAMESPACE", dockerHostNamespace)
+	dockerHostReuseType = helpers.GetEnv("DOCKERHOST_REUSE_TYPE", dockerHostReuseType)
 
 	if enablePodProxy {
 		httpProxy = helpers.GetEnv("HTTP_PROXY", httpProxy)
@@ -738,6 +750,22 @@ func main() {
 		cache,
 	)
 
+	reuseCache, _ := lru.New[string, string](1000)
+	buildCache, _ := lru.New[string, string](1000)
+	switch dockerHostReuseType {
+	case "namespace", "project", "organization":
+		// nothing to do here
+	default:
+		setupLog.Error(fmt.Errorf("unsupported docker-host reuse type"), "problem configuring docker-host handler")
+		os.Exit(1)
+	}
+	dockerhosts := dockerhost.New(
+		mgr.GetClient(),
+		dockerHostNamespace,
+		dockerHostReuseType,
+		reuseCache,
+		buildCache,
+	)
 	c := cron.New()
 	// if we are running with MQ support, then start the consumer handler
 
@@ -907,6 +935,7 @@ func main() {
 		},
 		UnauthenticatedRegistry: unauthenticatedRegistry,
 		ImagePullPolicy:         bipp,
+		DockerHost:              dockerhosts,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LagoonBuild")
 		os.Exit(1)
@@ -957,6 +986,7 @@ func main() {
 		LFFQoSEnabled:         lffQoSEnabled,
 		BuildQoS:              buildQoSConfigv1beta2,
 		Cache:                 cache,
+		DockerHost:            dockerhosts,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LagoonBuildPodMonitor")
 		os.Exit(1)

--- a/internal/controllers/v1beta2/build_controller.go
+++ b/internal/controllers/v1beta2/build_controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lagooncrd "github.com/uselagoon/remote-controller/api/lagoon/v1beta2"
+	"github.com/uselagoon/remote-controller/internal/dockerhost"
 	"github.com/uselagoon/remote-controller/internal/harbor"
 	"github.com/uselagoon/remote-controller/internal/helpers"
 	"github.com/uselagoon/remote-controller/internal/messenger"
@@ -79,6 +80,7 @@ type LagoonBuildReconciler struct {
 	ProxyConfig                      ProxyConfig
 	UnauthenticatedRegistry          string
 	ImagePullPolicy                  corev1.PullPolicy
+	DockerHost                       *dockerhost.DockerHost
 }
 
 // BackupConfig holds all the backup configuration settings

--- a/internal/controllers/v1beta2/build_helpers.go
+++ b/internal/controllers/v1beta2/build_helpers.go
@@ -823,6 +823,38 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 		Name:      newPod.ObjectMeta.Name,
 	}, newPod)
 	if err != nil {
+		// check the dockerhosts and assign as required
+		reuseType := lagoonBuild.ObjectMeta.Namespace
+		switch r.DockerHost.ReuseType {
+		case "project":
+			reuseType = lagoonBuild.Spec.Project.Name
+		case "organization":
+			if lagoonBuild.Spec.Project.Organization != nil {
+				reuseType = lagoonBuild.Spec.Project.Organization.Name
+			} else {
+				// fall back to project name if organization not found
+				reuseType = lagoonBuild.Spec.Project.Name
+			}
+		}
+		dockerHost, err := r.DockerHost.AssignDockerHost(
+			lagoonBuild.ObjectMeta.Name,
+			reuseType,
+			r.LFFQoSEnabled,
+			r.BuildQoS.MaxBuilds,
+		)
+		if err != nil {
+			opLog.Error(err, "Unable to determine dockerhost, using default host")
+		}
+		podEnvs = append(podEnvs, corev1.EnvVar{
+			Name:  "DOCKER_HOST",
+			Value: dockerHost,
+		})
+		newPod.ObjectMeta.Annotations = map[string]string{
+			"dockerhost.lagoon.sh/name": dockerHost,
+		}
+		newPod.Spec.Containers[0].Env = append(newPod.Spec.Containers[0].Env, podEnvs...)
+		opLog.Info(fmt.Sprintf("Assigning build %s to dockerhost %s", lagoonBuild.ObjectMeta.Name, dockerHost))
+
 		// if it doesn't exist, then create the build pod
 		opLog.Info(fmt.Sprintf("Creating build pod for: %s", lagoonBuild.ObjectMeta.Name))
 		if err := r.Create(ctx, newPod); err != nil {
@@ -832,8 +864,9 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 			return nil
 		}
 		metrics.BuildRunningStatus.With(prometheus.Labels{
-			"build_namespace": lagoonBuild.ObjectMeta.Namespace,
-			"build_name":      lagoonBuild.ObjectMeta.Name,
+			"build_namespace":  lagoonBuild.ObjectMeta.Namespace,
+			"build_name":       lagoonBuild.ObjectMeta.Name,
+			"build_dockerhost": dockerHost,
 		}).Set(1)
 		metrics.BuildStatus.With(prometheus.Labels{
 			"build_namespace": lagoonBuild.ObjectMeta.Namespace,

--- a/internal/controllers/v1beta2/build_helpers.go
+++ b/internal/controllers/v1beta2/build_helpers.go
@@ -836,23 +836,20 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 				reuseType = lagoonBuild.Spec.Project.Name
 			}
 		}
-		dockerHost, err := r.DockerHost.AssignDockerHost(
+		dockerHost := r.DockerHost.AssignDockerHost(
 			lagoonBuild.ObjectMeta.Name,
 			reuseType,
 			r.LFFQoSEnabled,
 			r.BuildQoS.MaxBuilds,
 		)
-		if err != nil {
-			opLog.Error(err, "Unable to determine dockerhost, using default host")
-		}
-		podEnvs = append(podEnvs, corev1.EnvVar{
+		dockerHostEnvVar := corev1.EnvVar{
 			Name:  "DOCKER_HOST",
 			Value: dockerHost,
-		})
+		}
 		newPod.ObjectMeta.Annotations = map[string]string{
 			"dockerhost.lagoon.sh/name": dockerHost,
 		}
-		newPod.Spec.Containers[0].Env = append(newPod.Spec.Containers[0].Env, podEnvs...)
+		newPod.Spec.Containers[0].Env = append(newPod.Spec.Containers[0].Env, dockerHostEnvVar)
 		opLog.Info(fmt.Sprintf("Assigning build %s to dockerhost %s", lagoonBuild.ObjectMeta.Name, dockerHost))
 
 		// if it doesn't exist, then create the build pod

--- a/internal/dockerhost/dockerhost.go
+++ b/internal/dockerhost/dockerhost.go
@@ -1,0 +1,187 @@
+package dockerhost
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sort"
+	"strconv"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/uselagoon/remote-controller/internal/helpers"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type DockerHost struct {
+	Client              client.Client
+	DockerHostNamespace string
+	ReuseType           string
+	ReuseCache          *lru.Cache[string, string]
+	BuildCache          *lru.Cache[string, string]
+}
+
+func (d *DockerHost) AssignDockerHost(buildName, reuseIdentifier string, qos bool, qosMax int) (string, error) {
+	ctx := context.TODO()
+	dockerHost := fmt.Sprintf("docker-host.%s.svc", d.DockerHostNamespace) // default dockerhost
+	dockerHosts := &corev1.ServiceList{}
+	listOption := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
+		client.InNamespace(d.DockerHostNamespace),
+		client.MatchingLabels(map[string]string{"dockerhost.lagoon.sh/dedicated": "true"}),
+	})
+	// list all dockerhost ports
+	if err := d.Client.List(ctx, dockerHosts, listOption); err != nil {
+		// return the default dockerhost
+		return dockerHost, fmt.Errorf("unable to list dockerhosts in the lagoon namespace, there may be none or something went wrong: %v", err)
+	}
+
+	// check available dockerhosts
+	availableHosts := []string{}
+	sort.Slice(dockerHosts.Items, func(i, j int) bool { return dockerHosts.Items[i].Name < dockerHosts.Items[j].Name })
+	for _, dh := range dockerHosts.Items {
+		dhsvc := fmt.Sprintf("%s.%s.svc", dh.Name, d.DockerHostNamespace)
+		for _, port := range dh.Spec.Ports {
+			// network policy may need to be adjusted in chart to support a controller installed in a non lagoon namespace
+			if tcpCheck(dhsvc, strconv.Itoa(int(port.Port))) {
+				availableHosts = append(availableHosts, dhsvc)
+			}
+		}
+	}
+
+	if cacheHost, ok := d.ReuseCache.Get(reuseIdentifier); ok {
+		if helpers.ContainsString(availableHosts, cacheHost) {
+			// if the namespace has already got a host assigned, prefer it
+			dockerHost = cacheHost
+		}
+	}
+
+	// pick a host to use
+	hostsInUse := countDupes(d.BuildCache.Values())
+	dockerHost = d.pickHost(dockerHost, availableHosts, hostsInUse, qosMax, qos)
+	// finally assign in the cache
+	_ = d.BuildCache.Add(buildName, dockerHost)
+	_ = d.ReuseCache.Add(reuseIdentifier, dockerHost)
+	return dockerHost, nil
+}
+
+func New(client client.Client,
+	dockerHostNamespace,
+	reuseType string,
+	reuseCache,
+	buildCache *lru.Cache[string, string],
+) *DockerHost {
+	return &DockerHost{
+		Client:              client,
+		DockerHostNamespace: dockerHostNamespace,
+		ReuseType:           reuseType,
+		ReuseCache:          reuseCache,
+		BuildCache:          buildCache,
+	}
+}
+
+func tcpCheck(host string, port string) bool {
+	timeout := 5 * time.Second
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), timeout)
+	if err != nil {
+		fmt.Println(err)
+		return false
+	}
+	if conn != nil {
+		defer conn.Close()
+	}
+	return true
+}
+
+func countDupes(list []string) map[string]int {
+	dupeFreq := make(map[string]int)
+	for _, item := range list {
+		// check if the item/element exist in the map
+		_, exist := dupeFreq[item]
+		if exist {
+			dupeFreq[item] += 1 // increase counter by 1 if already in the map
+		} else {
+			dupeFreq[item] = 1 // else start counting from 1
+		}
+	}
+	return dupeFreq
+}
+
+// pick host will attempt to determine the most suitable docker host to use with limited information
+// without deep inspecting the docker hosts for actual usage/consumption, just use the number of builds as an estimate
+func (d *DockerHost) pickHost(chosenHost string, availableHosts []string, hostsInUse map[string]int, qosMax int, qos bool) string {
+	buildsPerHost := 0
+	numAvailableHosts := len(availableHosts)
+	if numAvailableHosts == 0 {
+		// return the default docker-host if no available hosts
+		return fmt.Sprintf("docker-host.%s.svc", d.DockerHostNamespace) // default dockerhost
+	}
+	if qos {
+		// if qos enabled, work out how many builds per host can be used
+		buildsPerHost = qosMax / numAvailableHosts
+		if buildsPerHost%2 != 0 {
+			// add one so that if the number of builds is odd
+			// it will favor building on the host it may have already run on
+			// to try leverage cache where possible
+			buildsPerHost = buildsPerHost + 1
+		}
+	} else {
+		// work out how many builds per host based on distribution
+		totBuilds := 0
+		for _, boh := range hostsInUse {
+			totBuilds = totBuilds + boh
+		}
+		if totBuilds > 0 {
+			buildsPerHost = totBuilds / numAvailableHosts
+			if buildsPerHost%2 != 0 {
+				// add one so that if the number of builds is odd
+				// it will favor building on the host it may have already run on
+				// to try leverage cache where possible
+				buildsPerHost = buildsPerHost + 1
+			}
+		} else {
+			// default to 2, as builds increase this will be ignored
+			// set to 2 just to allow builds to schedule properly somewhere
+			buildsPerHost = 2
+		}
+	}
+	for h := range hostsInUse {
+		if !helpers.ContainsString(availableHosts, h) {
+			// delete any no longer available hosts from the in use table to force selection of another
+			delete(hostsInUse, h)
+		}
+	}
+	for _, availableHost := range availableHosts {
+		if _, ok := hostsInUse[availableHost]; !ok {
+			// add any other available docker hosts with 0 to indicate they're not in use
+			hostsInUse[availableHost] = 0
+		}
+	}
+	dockerHosts := make([]string, 0, len(hostsInUse))
+	for dockerHost := range hostsInUse {
+		dockerHosts = append(dockerHosts, dockerHost)
+	}
+	// sort dockerhosts, lowest in use first
+	sort.Slice(dockerHosts, func(i, j int) bool { return hostsInUse[dockerHosts[i]] < hostsInUse[dockerHosts[j]] })
+
+	// work out the best host to use
+	if buildsOnHost, ok := hostsInUse[chosenHost]; ok && buildsOnHost < buildsPerHost {
+		// if the chosen host exists and has free build slots, use it
+		return chosenHost
+	}
+	for _, host := range dockerHosts {
+		buildsOnHost := hostsInUse[host]
+		if host == chosenHost && buildsOnHost >= buildsPerHost {
+			// chosen host is too busy
+			continue
+		} else if buildsOnHost >= buildsPerHost {
+			// host is too busy
+			continue
+		} else {
+			// next lowest host in use
+			return host
+		}
+	}
+	// just use the chosen host as the fall back
+	return chosenHost
+}

--- a/internal/dockerhost/dockerhost_test.go
+++ b/internal/dockerhost/dockerhost_test.go
@@ -5,6 +5,7 @@ import (
 
 	lru "github.com/hashicorp/golang-lru/v2"
 	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -141,7 +142,8 @@ func Test_pickHost(t *testing.T) {
 			clientBuilder = clientBuilder.WithScheme(k8sScheme)
 
 			fakeClient := clientBuilder.Build()
-			d := New(fakeClient, "lagoon", tt.args.reuseType, &lru.Cache[string, string]{}, &lru.Cache[string, string]{})
+			logs := ctrl.Log.WithName("dockerhost")
+			d := New(fakeClient, logs, "lagoon", tt.args.reuseType, &lru.Cache[string, string]{}, &lru.Cache[string, string]{})
 			if got := d.pickHost(tt.args.chosen, tt.args.available, tt.args.inUse, tt.args.qosMax, tt.args.qos); got != tt.want {
 				t.Errorf("pickHost() = %v, want %v", got, tt.want)
 			}

--- a/internal/dockerhost/dockerhost_test.go
+++ b/internal/dockerhost/dockerhost_test.go
@@ -1,0 +1,150 @@
+package dockerhost
+
+import (
+	"testing"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func Test_pickHost(t *testing.T) {
+	type args struct {
+		reuseType string
+		chosen    string
+		available []string
+		inUse     map[string]int
+		qosMax    int
+		qos       bool
+	}
+	tests := []struct {
+		name        string
+		description string
+		args        args
+		want        string
+	}{
+		{
+			name:        "test1",
+			description: "qos, choose lowest in use dockerhost",
+			args: args{
+				chosen: "dockerhost1",
+				available: []string{
+					"dockerhost1",
+					"dockerhost2",
+				},
+				inUse: map[string]int{
+					"dockerhost1": 2,
+				},
+				qosMax: 3,
+				qos:    true,
+			},
+			want: "dockerhost2",
+		},
+		{
+			name:        "test2",
+			description: "qos, choose lowest in use dockerhost",
+			args: args{
+				chosen: "dockerhost2",
+				available: []string{
+					"dockerhost1",
+					"dockerhost2",
+				},
+				inUse: map[string]int{
+					"dockerhost1": 2,
+				},
+				qosMax: 3,
+				qos:    true,
+			},
+			want: "dockerhost2",
+		},
+		{
+			name:        "test3",
+			description: "qos, in use dockerhost no longer exists choose from available",
+			args: args{
+				chosen: "dockerhost2",
+				available: []string{
+					"dockerhost2",
+				},
+				inUse: map[string]int{
+					"dockerhost1": 2,
+				},
+				qosMax: 3,
+				qos:    true,
+			},
+			want: "dockerhost2",
+		},
+		{
+			name:        "test4",
+			description: "qos, choose lowest in use dockerhost",
+			args: args{
+				chosen: "dockerhost2",
+				available: []string{
+					"dockerhost1",
+					"dockerhost2",
+					"dockerhost3",
+				},
+				inUse: map[string]int{
+					"dockerhost1": 2,
+					"dockerhost2": 1,
+					"dockerhost3": 2,
+				},
+				qosMax: 3,
+				qos:    true,
+			},
+			want: "dockerhost2",
+		},
+		{
+			name:        "test5",
+			description: "no qos, prefer lowest in use dockerhost which is chosen",
+			args: args{
+				chosen: "dockerhost2",
+				available: []string{
+					"dockerhost1",
+					"dockerhost2",
+					"dockerhost3",
+				},
+				inUse: map[string]int{
+					"dockerhost1": 2,
+					"dockerhost2": 1,
+					"dockerhost3": 2,
+				},
+				qosMax: 20,
+				qos:    false,
+			},
+			want: "dockerhost2",
+		},
+		{
+			name:        "test6",
+			description: "no qos, prefer lowest in use dockerhost when chosen is busier",
+			args: args{
+				chosen: "dockerhost3",
+				available: []string{
+					"dockerhost1",
+					"dockerhost2",
+					"dockerhost3",
+				},
+				inUse: map[string]int{
+					"dockerhost1": 2,
+					"dockerhost2": 1,
+					"dockerhost3": 2,
+				},
+				qosMax: 20,
+				qos:    false,
+			},
+			want: "dockerhost2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sScheme := runtime.NewScheme()
+			clientBuilder := ctrlfake.NewClientBuilder()
+			clientBuilder = clientBuilder.WithScheme(k8sScheme)
+
+			fakeClient := clientBuilder.Build()
+			d := New(fakeClient, "lagoon", tt.args.reuseType, &lru.Cache[string, string]{}, &lru.Cache[string, string]{})
+			if got := d.pickHost(tt.args.chosen, tt.args.available, tt.args.inUse, tt.args.qosMax, tt.args.qos); got != tt.want {
+				t.Errorf("pickHost() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -100,6 +100,7 @@ var (
 		[]string{
 			"build_name",
 			"build_namespace",
+			"build_dockerhost",
 		},
 	)
 	TaskRunningStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

With the support for multiple dockerhosts being made [available](https://github.com/uselagoon/lagoon-charts/pull/687) in `lagoon-remote`. The `remote-controller` behaviour was previously to send builds to the main service that would use session to distribute amongst the dockerhosts.

This feature will now allow the remote-controller to detect the available dockerhosts in a remote and how many there are, and attempt to distribute builds amongst them.

The preference will be to assign a build for an environment to the same dockerhost that previous builds for that environment were built on to benefit from caching. During the event though where there is a lot of builds on that host and others are less used, the process will pick a dockerhost that has less builds on it to prevent congestion on a busy one. The downsides to this would be that there may be no pre-existing cache present, so the build may take longer.

# Closing issues

closes #239 