### PR TITLE
fix: check the returned credentials before using

### DIFF
--- a/internal/controllers/harbor/harborcredential_controller.go
+++ b/internal/controllers/harbor/harborcredential_controller.go
@@ -52,7 +52,7 @@ func (r *HarborCredentialReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		rotated, err := lagoonHarbor.RotateRobotCredential(ctx, r.Client, ns, true)
 		if err != nil {
 			// @TODO: resource unknown
-			return ctrl.Result{}, fmt.Errorf("error was: %v", err)
+			return ctrl.Result{}, fmt.Errorf("error rotating robot credential was: %v", err)
 		}
 		if rotated {
 			opLog.Info(fmt.Sprintf("Robot credentials rotated for %s", ns.ObjectMeta.Name))

--- a/internal/harbor/harbor_credentialrotation.go
+++ b/internal/harbor/harbor_credentialrotation.go
@@ -47,7 +47,7 @@ func (h *Harbor) RotateRobotCredentials(ctx context.Context, cl client.Client) {
 		if !runningBuildsv1beta2 {
 			rotated, err := h.RotateRobotCredential(ctx, cl, ns, false)
 			if err != nil {
-				opLog.Error(err, "error")
+				opLog.Error(err, "error rotating robot credential")
 				continue
 			}
 			if rotated {


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Fixes a missed rotated credential check from #288 (https://github.com/uselagoon/remote-controller/pull/288/files#diff-487cd9eccb6a4367ed44e85119021df097dc1793b120a6a58b1a29bf331fcd54R91) that needed to be added to the `build_helpers.go` file to support checking if the credential was actually rotated. Instead I replaced the duplicated logic with the `RotateRobotCredential` call which already handled this.