### PR TITLE
feat: support for harbor 2.13.x

### DIFF
--- a/.github/workflows/remote-controller.yaml
+++ b/.github/workflows/remote-controller.yaml
@@ -31,7 +31,7 @@ jobs:
             lagoon_build_image: "uselagoon/build-deploy-image:main"
             experimental: true
           - kindest_node_version: v1.30.2
-            harbor: "1.14.3"
+            harbor: "1.17.1"
             lagoon_build_image: "uselagoon/build-deploy-image:main"
             experimental: true
     steps:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OVERRIDE_BUILD_DEPLOY_DIND_IMAGE ?= uselagoon/build-deploy-image:main
 
 INGRESS_VERSION=4.9.1
 
-HARBOR_VERSION=1.14.3
+HARBOR_VERSION=1.17.1
 
 KIND_CLUSTER ?= remote-controller
 KIND_NETWORK ?= remote-controller

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.23.2
 toolchain go1.23.3
 
 require (
-	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/cheshir/go-mq/v2 v2.0.1
 	github.com/coreos/go-semver v0.3.1
 	github.com/docker/cli v27.1.1+incompatible
@@ -13,7 +12,8 @@ require (
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/k8up-io/k8up/v2 v2.11.3
-	github.com/mittwald/goharbor-client/v5 v5.6.3
+	github.com/matryer/try v0.0.0-20161228173917-9ac251b645a2
+	github.com/mittwald/goharbor-client/v5 v5.6.4
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
@@ -78,7 +78,6 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
-	github.com/matryer/try v0.0.0-20161228173917-9ac251b645a2 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
@@ -93,7 +92,6 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rabbitmq/amqp091-go v1.10.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
-	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
@@ -138,6 +136,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.5.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-// includes page_size 100 for listing projects
-replace github.com/mittwald/goharbor-client/v3 v3.3.0 => github.com/shreddedbacon/goharbor-client/v3 v3.0.0-20210618042159-ceb1f437ad75

--- a/go.sum
+++ b/go.sum
@@ -124,7 +124,6 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/alexflint/go-filemutex v1.1.0/go.mod h1:7P4iRhttt/nUvUOrYIhcpMzv2G6CY9UnI16Z+UJqRyk=
-github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -896,8 +895,8 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/mittwald/goharbor-client/v5 v5.6.3 h1:u5wloYEJv28t1KgDjnaXIaT/+aOlYjcwF47UD+AdN34=
-github.com/mittwald/goharbor-client/v5 v5.6.3/go.mod h1:K23Lm2P6qpZlt/c7mv1BWIMEUbkSKZ3N/xMn/WD3YNc=
+github.com/mittwald/goharbor-client/v5 v5.6.4 h1:Ic2+L9iHy2bR1Q+/miO+veK+b6cb9p9qJXxhp7KlTnE=
+github.com/mittwald/goharbor-client/v5 v5.6.4/go.mod h1:K23Lm2P6qpZlt/c7mv1BWIMEUbkSKZ3N/xMn/WD3YNc=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/patternmatcher v0.5.0 h1:YCZgJOeULcxLw1Q+sVR636pmS7sPEn1Qo2iAN6M7DBo=
 github.com/moby/patternmatcher v0.5.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
@@ -1118,7 +1117,6 @@ github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvW
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/securego/gosec v0.0.0-20191002120514-e680875ea14d/go.mod h1:w5+eXa0mYznDkHaMCXA4XYffjlH+cy1oyKbfzJXa2Do=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=

--- a/internal/utilities/deletions/process.go
+++ b/internal/utilities/deletions/process.go
@@ -89,7 +89,12 @@ func (d *Deletions) ProcessDeletion(ctx context.Context, opLog logr.Logger, name
 					lagoonHarbor.DeleteRepository(ctx, project, environment)
 				}
 				if cleanupRobot {
-					lagoonHarbor.DeleteRobotAccount(ctx, project, environment)
+					projectHarbor, err := lagoonHarbor.ClientV5.GetProject(ctx, project)
+					if err != nil {
+						opLog.Info(fmt.Sprintf("Error getting project %s, err: %v", project, err))
+						return err
+					}
+					lagoonHarbor.DeleteRobotAccount(ctx, int64(projectHarbor.ProjectID), project, environment)
 				}
 			}
 		}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -452,7 +453,10 @@ var _ = Describe("controller", Ordered, func() {
 				)
 				podlogs, err := utils.Run(cmd)
 				ExpectWithOffset(2, err).NotTo(HaveOccurred())
-				if !strings.Contains(string(podlogs), "Robot credentials rotated for nginx-example-main") {
+				re := regexp.MustCompile(`Robot credentials rotated for nginx-example-`)
+				matches := re.FindAllString(string(podlogs), -1)
+				// if there are less than 4 rotation logs, then consider the rotations failed and check for ERROR in the logs
+				if len(matches) < 4 {
 					return fmt.Errorf("robot credentials not rotated yet")
 				}
 				return nil


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

The client library we use for Harbor doesn't directly support querying for project robot accounts, which is used by the remote-controller and Lagoon to create robot accounts.

Refactored the client creation to include query parameter overrides to set the query for project level queries for robot accounts.

# Closing issues

closes #307 