### PR TITLE
feat: default label to prevent autoscaler evictions on pods

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1025,11 +1025,12 @@ func main() {
 			HTTPSProxy: httpsProxy,
 			NoProxy:    noProxy,
 		},
-		LFFTaskQoSEnabled: lffTaskQoSEnabled,
-		TaskQoS:           taskQoSConfigv1beta2,
-		ImagePullPolicy:   tipp,
-		QueueCache:        tasksQueueCache,
-		TasksCache:        tasksCache,
+		LFFTaskQoSEnabled:      lffTaskQoSEnabled,
+		TaskQoS:                taskQoSConfigv1beta2,
+		ImagePullPolicy:        tipp,
+		QueueCache:             tasksQueueCache,
+		TasksCache:             tasksCache,
+		ClusterAutoscalerEvict: clusterAutoscalerEvict,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LagoonTask")
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -199,6 +199,8 @@ func main() {
 	var dockerHostNamespace string
 	var dockerHostReuseType string
 
+	var clusterAutoscalerEvict bool
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.BoolVar(&secureMetrics, "metrics-secure", true,
@@ -429,6 +431,10 @@ func main() {
 	flag.StringVar(&dockerHostReuseType, "docker-host-reuse-type", "namespace",
 		`The resource type (namespace, project, organization) to use when assigning a docker-host to a build to preference an already used dockerhost
 		eg. If project is defined, all builds from a project will prefer to build on the same docker-host where possible`)
+
+	// Flag to control the setting for the label cluster-autoscaler.kubernetes.io/safe-to-evict on build pods, defaults to false to avoid evicting pods
+	flag.BoolVar(&clusterAutoscalerEvict, "enable-cluster-autoscaler-eviction", false,
+		"Flag to enable cluster autoscaler eviction on build pods, defaults to false to avoid evicting running builds")
 
 	flag.Parse()
 
@@ -990,6 +996,7 @@ func main() {
 		DockerHost:              dockerhosts,
 		QueueCache:              buildsQueueCache,
 		BuildCache:              buildsCache,
+		ClusterAutoscalerEvict:  clusterAutoscalerEvict,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LagoonBuild")
 		os.Exit(1)

--- a/internal/controllers/v1beta2/build_controller.go
+++ b/internal/controllers/v1beta2/build_controller.go
@@ -84,6 +84,7 @@ type LagoonBuildReconciler struct {
 	DockerHost                       *dockerhost.DockerHost
 	QueueCache                       *lru.Cache[string, string]
 	BuildCache                       *lru.Cache[string, string]
+	ClusterAutoscalerEvict           bool
 }
 
 // BackupConfig holds all the backup configuration settings

--- a/internal/controllers/v1beta2/build_helpers.go
+++ b/internal/controllers/v1beta2/build_helpers.go
@@ -799,6 +799,11 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 		newPod.Labels["organization.lagoon.sh/name"] = lagoonBuild.Spec.Project.Organization.Name
 	}
 
+	if !r.ClusterAutoscalerEvict {
+		// try to prevent build pods from being evicted by cluster autoscaler
+		newPod.Labels["cluster-autoscaler.kubernetes.io/safe-to-evict"] = "false"
+	}
+
 	// set the pod security context, if defined to a non-default value
 	if r.BuildPodRunAsUser != 0 || r.BuildPodRunAsGroup != 0 ||
 		r.BuildPodFSGroup != 0 {


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

This adds a new feature that will add the label `cluster-autoscaler.kubernetes.io/safe-to-evict` ([see more](https://kubernetes.io/docs/reference/labels-annotations-taints/#cluster-autoscaler-kubernetes-io-safe-to-evict)) to build and task pods with the value `false`.

This is done to prevent build pods from being evicted by cluster autoscaler. This flag is disabled by default, meaning build and tasks pods will (hopefully) not be evicted, you can enable it if you do want pods to be evicted.