### PR TITLE
feat: add project/environment labels to Lagoon build/task pods

### DIFF
--- a/internal/controllers/v1beta2/build_helpers.go
+++ b/internal/controllers/v1beta2/build_helpers.go
@@ -629,11 +629,14 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 			Name:      lagoonBuild.Name,
 			Namespace: lagoonBuild.Namespace,
 			Labels: map[string]string{
-				"lagoon.sh/jobType":       "build",
-				"lagoon.sh/buildName":     lagoonBuild.Name,
-				"lagoon.sh/controller":    r.ControllerNamespace,
-				"crd.lagoon.sh/version":   crdVersion,
-				"lagoon.sh/buildRemoteID": string(lagoonBuild.UID),
+				"lagoon.sh/jobType":         "build",
+				"lagoon.sh/buildName":       lagoonBuild.Name,
+				"lagoon.sh/project":         lagoonBuild.Spec.Project.Name,
+				"lagoon.sh/environment":     lagoonBuild.Spec.Project.Environment,
+				"lagoon.sh/environmentType": lagoonBuild.Spec.Project.EnvironmentType,
+				"lagoon.sh/controller":      r.ControllerNamespace,
+				"crd.lagoon.sh/version":     crdVersion,
+				"lagoon.sh/buildRemoteID":   string(lagoonBuild.UID),
 			},
 			Annotations: map[string]string{},
 			OwnerReferences: []metav1.OwnerReference{
@@ -687,6 +690,13 @@ func (r *LagoonBuildReconciler) processBuild(ctx context.Context, opLog logr.Log
 	if lagoonBuild.Spec.Project.Organization != nil {
 		newPod.Labels["organization.lagoon.sh/id"] = fmt.Sprintf("%d", *lagoonBuild.Spec.Project.Organization.ID)
 		newPod.Labels["organization.lagoon.sh/name"] = lagoonBuild.Spec.Project.Organization.Name
+	}
+
+	if lagoonBuild.Spec.Project.ID != nil {
+		newPod.Labels["lagoon.sh/projectId"] = fmt.Sprintf("%d", *lagoonBuild.Spec.Project.ID)
+	}
+	if lagoonBuild.Spec.Project.EnvironmentID != nil {
+		newPod.Labels["lagoon.sh/environmentId"] = fmt.Sprintf("%d", *lagoonBuild.Spec.Project.EnvironmentID)
 	}
 
 	if !r.ClusterAutoscalerEvict {

--- a/internal/controllers/v1beta2/task_controller.go
+++ b/internal/controllers/v1beta2/task_controller.go
@@ -304,6 +304,7 @@ func (r *LagoonTaskReconciler) getTaskPodDeployment(ctx context.Context, lagoonT
 						Labels: map[string]string{
 							"lagoon.sh/jobType":     "task",
 							"lagoon.sh/taskName":    lagoonTask.Name,
+							"lagoon.sh/project":     lagoonTask.Spec.Project.Name,
 							"crd.lagoon.sh/version": crdVersion,
 							"lagoon.sh/controller":  r.ControllerNamespace,
 						},
@@ -323,6 +324,10 @@ func (r *LagoonTaskReconciler) getTaskPodDeployment(ctx context.Context, lagoonT
 				if lagoonTask.Spec.Project.Organization != nil {
 					taskPod.Labels["organization.lagoon.sh/id"] = fmt.Sprintf("%d", *lagoonTask.Spec.Project.Organization.ID)
 					taskPod.Labels["organization.lagoon.sh/name"] = lagoonTask.Spec.Project.Organization.Name
+				}
+
+				if lagoonTask.Spec.Project.ID != nil {
+					taskPod.Labels["lagoon.sh/projectId"] = fmt.Sprintf("%d", *lagoonTask.Spec.Project.ID)
 				}
 
 				if !r.ClusterAutoscalerEvict {


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Currently build/task pods have labels that allow selection based on type (build or task) and organization, but I found it would also be useful to select all for a project. For example, if a project has a build image override, it's not possible to select (or modify, eg kyverno) all build/task pods in all environments for a project.

This PR adds project/environment labels for build pods and project labels for task pods.

# Closing issues

n/a