### PR TITLE
feat: support for latestpushed retention rule

### DIFF
--- a/internal/messenger/task_harborpolicy.go
+++ b/internal/messenger/task_harborpolicy.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	harborclientv5model "github.com/mittwald/goharbor-client/v5/apiv2/model"
+	retention "github.com/mittwald/goharbor-client/v5/apiv2/pkg/clients/retention"
 	"github.com/uselagoon/machinery/utils/cron"
 	lagoonv1beta2 "github.com/uselagoon/remote-controller/api/lagoon/v1beta2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -38,6 +39,7 @@ type HarborRetentionRule struct {
 	Name         string `json:"name"`
 	Pattern      string `json:"pattern"`
 	LatestPulled uint64 `json:"latestPulled"`
+	LatestPushed uint64 `json:"latestPushed"`
 }
 
 // HarborPolicy handles harbor retention policy changes.
@@ -134,11 +136,36 @@ func (m *Messenger) generateRetentionPolicy(projectID int64, projectName string,
 		},
 	}
 	for _, rule := range policy.Rules {
-		retPol.Rules = append(retPol.Rules,
-			&harborclientv5model.RetentionRule{
+		pulledRule := &harborclientv5model.RetentionRule{
+			Action: "retain",
+			Params: map[string]interface{}{
+				retention.PolicyTemplateLatestPulledArtifacts.String(): rule.LatestPulled,
+			},
+			ScopeSelectors: map[string][]harborclientv5model.RetentionSelector{
+				"repository": {
+					{
+						Decoration: "repoMatches",
+						Kind:       "doublestar",
+						Pattern:    rule.Pattern,
+					},
+				},
+			},
+			TagSelectors: []*harborclientv5model.RetentionSelector{
+				{
+					Decoration: "matches",
+					Extras:     "{\"untagged\":true}",
+					Kind:       "doublestar",
+					Pattern:    "**",
+				},
+			},
+			Template: retention.PolicyTemplateLatestPulledArtifacts.String(),
+		}
+		retPol.Rules = append(retPol.Rules, pulledRule)
+		if rule.LatestPushed != 0 {
+			pushedRule := &harborclientv5model.RetentionRule{
 				Action: "retain",
 				Params: map[string]interface{}{
-					"latestPulledN": rule.LatestPulled,
+					retention.PolicyTemplateLatestPushedArtifacts.String(): rule.LatestPushed,
 				},
 				ScopeSelectors: map[string][]harborclientv5model.RetentionSelector{
 					"repository": {
@@ -157,9 +184,10 @@ func (m *Messenger) generateRetentionPolicy(projectID int64, projectName string,
 						Pattern:    "**",
 					},
 				},
-				Template: "latestPulledN",
-			},
-		)
+				Template: retention.PolicyTemplateLatestPushedArtifacts.String(),
+			}
+			retPol.Rules = append(retPol.Rules, pushedRule)
+		}
 	}
 	return retPol, nil
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -63,6 +63,8 @@ var (
 
 	createPolicyWant        = `{"algorithm":"or","rules":[{"action":"retain","params":{"latestPulledN":3},"scope_selectors":{"repository":[{"decoration":"repoMatches","kind":"doublestar","pattern":"[^pr\\-]*/*"}]},"tag_selectors":[{"decoration":"matches","extras":"{\"untagged\":true}","kind":"doublestar","pattern":"**"}],"template":"latestPulledN"},{"action":"retain","params":{"latestPulledN":1},"scope_selectors":{"repository":[{"decoration":"repoMatches","kind":"doublestar","pattern":"pr-*"}]},"tag_selectors":[{"decoration":"matches","extras":"{\"untagged\":true}","kind":"doublestar","pattern":"**"}],"template":"latestPulledN"}],"scope":{"level":"project"},"trigger":{"kind":"Schedule","settings":{"cron":"0 3 3 * * 3"}}}`
 	deletePolicyWant        = `{"algorithm":"or","rules":[],"scope":{"level":"project"},"trigger":{"kind":"Schedule","settings":{"cron":""}}}`
+	createPolicyWant2       = `{"algorithm":"or","rules":[{"action":"retain","params":{"latestPulledN":3},"scope_selectors":{"repository":[{"decoration":"repoMatches","kind":"doublestar","pattern":"[^pr\\-]*/*"}]},"tag_selectors":[{"decoration":"matches","extras":"{\"untagged\":true}","kind":"doublestar","pattern":"**"}],"template":"latestPulledN"},{"action":"retain","params":{"latestPushedK":2},"scope_selectors":{"repository":[{"decoration":"repoMatches","kind":"doublestar","pattern":"[^pr\\-]*/*"}]},"tag_selectors":[{"decoration":"matches","extras":"{\"untagged\":true}","kind":"doublestar","pattern":"**"}],"template":"latestPushedK"}],"scope":{"level":"project"},"trigger":{"kind":"Schedule","settings":{"cron":"0 3 3 * * 3"}}}`
+	deletePolicyWant2       = `{"algorithm":"or","rules":[],"scope":{"level":"project"},"trigger":{"kind":"Schedule","settings":{"cron":""}}}`
 	projectRepositoriesWant = `[{"artifact_count":1,"name":"nginx-example/dev8/nginx"},{"artifact_count":1,"name":"nginx-example/dev7/nginx"},{"artifact_count":1,"name":"nginx-example/dev6/nginx"},{"artifact_count":1,"name":"nginx-example/dev5/nginx"},{"artifact_count":1,"name":"nginx-example/dev4/nginx"},{"artifact_count":1,"name":"nginx-example/dev3/nginx"},{"artifact_count":1,"name":"nginx-example/dev2/nginx"},{"artifact_count":1,"name":"nginx-example/dev1/nginx"},{"artifact_count":1,"name":"nginx-example/main/nginx"}]`
 )
 
@@ -501,6 +503,26 @@ var _ = Describe("controller", Ordered, func() {
 			after, err = utils.QueryHarborProjectPolicies(ip, "nginx-example")
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 			err = comparePolicy(deletePolicyWant, after)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			By("creating harbor policy 2 update via rabbitmq")
+			err = utils.PublishMessage("@test/e2e/testdata/create-retention-policy2.json")
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			time.Sleep(10 * time.Second)
+			By("check harbor project policies after creating policy 2")
+			after2, err := utils.QueryHarborProjectPolicies(ip, "nginx-example")
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			err = comparePolicy(createPolicyWant2, after2)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			By("delete harbor policy 2 via rabbitmq")
+			err = utils.PublishMessage("@test/e2e/testdata/remove-retention-policy.json")
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			time.Sleep(10 * time.Second)
+			By("check harbor project policies after deleting policy 2")
+			after, err = utils.QueryHarborProjectPolicies(ip, "nginx-example")
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			err = comparePolicy(deletePolicyWant2, after)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 			By("check harbor project repositories before deleting environment")

--- a/test/e2e/testdata/create-retention-policy2.json
+++ b/test/e2e/testdata/create-retention-policy2.json
@@ -1,0 +1,20 @@
+{"properties":{"delivery_mode":2},"routing_key":"ci-local-controller-kubernetes:misc",
+    "payload":"{
+        \"misc\":{
+            \"miscResource\":\"eyJ0eXBlIjoiaGFyYm9yUmV0ZW50aW9uUG9saWN5IiwiZXZlbnRUeXBlIjoidXBkYXRlUG9saWN5IiwiZGF0YSI6eyJwcm9qZWN0Ijp7ImlkIjoxLCJuYW1lIjoibmdpbngtZXhhbXBsZSJ9LCJwb2xpY3kiOnsicnVsZXMiOlt7Im5hbWUiOiJhbGwgYnJhbmNoZXMsIGV4Y2x1ZGluZyBwdWxscmVxdWVzdHMiLCJwYXR0ZXJuIjoiW15wclxcLV0qLyoiLCJsYXRlc3RQdWxsZWQiOjMsImxhdGVzdFB1c2hlZCI6Mn1dLCJzY2hlZHVsZSI6IjMgMyAqICogMyJ9fX0=\"
+        },
+        \"key\":\"deploytarget:harborpolicy:update\",
+        \"environment\":{
+            \"name\":\"main\",
+            \"openshiftProjectName\":\"nginx-example-main\"
+        },
+        \"project\":{
+            \"name\":\"nginx-example\"
+        },
+        \"advancedTask\":{}
+    }",
+"payload_encoding":"string"
+}
+
+
+


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

See https://github.com/uselagoon/lagoon/pull/4074 for description. This is supporting code changes for `latestPushed` retention policies.

As this code is only accessed if the message from core contains the information, this should be fine to merge ahead of the changes in core.