### PR TITLE
Disable auto_scan on push

### DIFF
--- a/internal/harbor/harbor_project.go
+++ b/internal/harbor/harbor_project.go
@@ -33,8 +33,9 @@ func (h *Harbor) CreateProjectV2(ctx context.Context, namespace corev1.Namespace
 		}
 		stor := int64(-1)
 		tStr := "true"
+		fStr := "false"
 		project.Metadata = &harborclientv5model.ProjectMetadata{
-			AutoScan:             &tStr,
+			AutoScan:             &fStr,
 			ReuseSysCVEAllowlist: &tStr,
 			Public:               "false",
 		}


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [x] PR title is ready for changelog and subsystem label(s) applied

Explain the **details** for making this change. What existing problem does the pull request solve?

When there is no scanner enabled in harbor, `auto_scan` should be set to `false` to stop errors `error: no available scanner for project` from producing logs.