### PR TITLE
refactor: namespace cleanup for harbor resources

### DIFF
--- a/internal/harbor/harbor_project.go
+++ b/internal/harbor/harbor_project.go
@@ -74,7 +74,7 @@ func (h *Harbor) DeleteRepository(ctx context.Context, projectName, branch strin
 			repoName := strings.Replace(repo.Name, fmt.Sprintf("%s/", projectName), "", 1)
 			err := h.ClientV5.DeleteRepository(ctx, projectName, repoName)
 			if err != nil {
-				h.Log.Info(fmt.Sprintf("Error deleting harbor repository %s", repo.Name))
+				h.Log.Info(fmt.Sprintf("Error deleting harbor repository %s: %v", repo.Name, err.Error()))
 			}
 			h.Log.Info(
 				fmt.Sprintf(
@@ -97,16 +97,18 @@ func (h *Harbor) DeleteRepository(ctx context.Context, projectName, branch strin
 					repoName := strings.Replace(repo.Name, fmt.Sprintf("%s/", projectName), "", 1)
 					err := h.ClientV5.DeleteRepository(ctx, projectName, repoName)
 					if err != nil {
-						h.Log.Info(fmt.Sprintf("Error deleting harbor repository %s", repo.Name))
+						//  don't block namespace deletion
+						h.Log.Info(fmt.Sprintf("Error deleting harbor repository %s: %v", repo.Name, err.Error()))
+					} else {
+						h.Log.Info(
+							fmt.Sprintf(
+								"Deleted harbor repository %s in  project %s, environment %s",
+								repo.Name,
+								projectName,
+								environmentName,
+							),
+						)
 					}
-					h.Log.Info(
-						fmt.Sprintf(
-							"Deleted harbor repository %s in  project %s, environment %s",
-							repo.Name,
-							projectName,
-							environmentName,
-						),
-					)
 				}
 			}
 		}

--- a/internal/harbor/harbor_robot.go
+++ b/internal/harbor/harbor_robot.go
@@ -147,23 +147,23 @@ func (h *Harbor) DeleteRobotAccount(ctx context.Context, projectID int64, projec
 	}
 	for _, robot := range robots {
 		if h.matchRobotAccountV2(robot.Name, projectName, environmentName) {
-			err := h.ClientV5.DeleteProjectRobotV1(
+			err := h.ClientV5.DeleteRobotAccountByID(
 				ctx,
-				projectName,
 				int64(robot.ID),
 			)
 			if err != nil {
-				h.Log.Info(fmt.Sprintf("Error deleting project %s robot account %s", projectName, robot.Name))
-				return
+				//  don't block namespace deletion
+				h.Log.Info(fmt.Sprintf("Error deleting project %s robot account %s: %v", projectName, robot.Name, err.Error()))
+			} else {
+				h.Log.Info(
+					fmt.Sprintf(
+						"Deleted harbor robot account %s in  project %s, environment %s",
+						robot.Name,
+						projectName,
+						environmentName,
+					),
+				)
 			}
-			h.Log.Info(
-				fmt.Sprintf(
-					"Deleted harbor robot account %s in  project %s, environment %s",
-					robot.Name,
-					projectName,
-					environmentName,
-				),
-			)
 		}
 	}
 }

--- a/internal/utilities/deletions/process.go
+++ b/internal/utilities/deletions/process.go
@@ -86,10 +86,11 @@ func (d *Deletions) ProcessDeletion(ctx context.Context, opLog logr.Logger, name
 				if cleanupRobot {
 					projectHarbor, err := d.Harbor.ClientV5.GetProject(ctx, project)
 					if err != nil {
+						//  don't block namespace deletion
 						opLog.Info(fmt.Sprintf("Error getting project %s, err: %v", project, err))
-						return err
+					} else {
+						d.Harbor.DeleteRobotAccount(ctx, int64(projectHarbor.ProjectID), project, environment)
 					}
-					d.Harbor.DeleteRobotAccount(ctx, int64(projectHarbor.ProjectID), project, environment)
 				}
 			}
 		}


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Small adjustments to repository and robot cleanup to log more of the error.

Replaces the delete robot account from the older V1 endpoint which is no longer valid (was returning 404) to use the newer robot deletion call.