### PR TITLE
fix: deprecated scheme builder registration

### DIFF
--- a/api/lagoon/v1beta1/groupversion_info.go
+++ b/api/lagoon/v1beta1/groupversion_info.go
@@ -19,8 +19,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -28,8 +29,19 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "crd.lagoon.sh", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&LagoonBuild{},
+		&LagoonTask{},
+		&LagoonBuildList{},
+		&LagoonTaskList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/lagoon/v1beta1/lagoonbuild_types.go
+++ b/api/lagoon/v1beta1/lagoonbuild_types.go
@@ -58,7 +58,3 @@ type LagoonBuildStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	Phase      string             `json:"phase,omitempty"`
 }
-
-func init() {
-	SchemeBuilder.Register(&LagoonBuild{}, &LagoonBuildList{})
-}

--- a/api/lagoon/v1beta1/lagoontask_types.go
+++ b/api/lagoon/v1beta1/lagoontask_types.go
@@ -57,7 +57,3 @@ type LagoonTaskStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	Phase      string             `json:"phase,omitempty"`
 }
-
-func init() {
-	SchemeBuilder.Register(&LagoonTask{}, &LagoonTaskList{})
-}

--- a/api/lagoon/v1beta2/groupversion_info.go
+++ b/api/lagoon/v1beta2/groupversion_info.go
@@ -19,8 +19,9 @@ limitations under the License.
 package v1beta2
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -28,8 +29,19 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "crd.lagoon.sh", Version: "v1beta2"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&LagoonBuild{},
+		&LagoonTask{},
+		&LagoonBuildList{},
+		&LagoonTaskList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/lagoon/v1beta2/lagoonbuild_types.go
+++ b/api/lagoon/v1beta2/lagoonbuild_types.go
@@ -99,10 +99,6 @@ type LagoonBuildStatus struct {
 	Phase      string             `json:"phase,omitempty"`
 }
 
-func init() {
-	SchemeBuilder.Register(&LagoonBuild{}, &LagoonBuildList{})
-}
-
 // Build contains the type of build, and the image to use for the builder.
 type Build struct {
 	CI       string `json:"ci,omitempty"`

--- a/api/lagoon/v1beta2/lagoontask_types.go
+++ b/api/lagoon/v1beta2/lagoontask_types.go
@@ -153,10 +153,6 @@ type LagoonTaskStatus struct {
 	Phase      string             `json:"phase,omitempty"`
 }
 
-func init() {
-	SchemeBuilder.Register(&LagoonTask{}, &LagoonTaskList{})
-}
-
 func jsonToBool(value interface{}) bool {
 	switch valueType := value.(type) {
 	case bool:


### PR DESCRIPTION
<!-- You can skip this if you're fixing a typo. -->
# Checklist

- [ ] Affected Issues have been mentioned in the Closing issues section
- [ ] Documentation has been written/updated
- [ ] PR title is ready for changelog and subsystem label(s) applied

Controller-runtime deprecated the previous method of registering scheme builder, and golangci-lint is now reporting this deprecation.